### PR TITLE
💄 Fix sizing of Nav Bar

### DIFF
--- a/components/shared/Blocks/BookingButton.tsx
+++ b/components/shared/Blocks/BookingButton.tsx
@@ -17,7 +17,7 @@ export const BookingButton = ({ title, jotFormId }: BookingButtonProps) => {
     <div>
       <button
         onClick={openModal}
-        className="md:px-5 md:py-4 px-2 py-1 bg-ssw-red md:font-semibold text-center items-center text-white rounded-lg hover:opacity-80 whitespace-nowrap"
+        className="md:px-5 md:py-2 px-2 py-1 bg-ssw-red md:font-semibold text-center items-center text-white rounded-lg hover:opacity-80 whitespace-nowrap"
       >
         {title}
       </button>

--- a/components/shared/NavBarClient.tsx
+++ b/components/shared/NavBarClient.tsx
@@ -38,7 +38,7 @@ export default function NavBarClient({ results }: NavBarClientProps) {
       case "NavigationBarLeftNavItemStringItem":
       case "NavigationBarRightNavItemStringItem":
         return (
-          <li key={index} className="flex items-center pt-2 lg:px-10 xl:px-0 md:px-6 px-4">
+          <li key={index} className="flex items-center lg:px-3 xl:px-0 md:px-3 px-2">
             <Link
               href={item.href}
               className="hover:underline md:text-xl"
@@ -103,12 +103,12 @@ export default function NavBarClient({ results }: NavBarClientProps) {
           scrolled
             ? 'bg-stone-700 bg-opacity-90 backdrop-blur-md'
             : 'bg-transparent'
-        } text-gray-300 fixed top-0 left-0 w-full z-50 transition-colors duration-300 flex justify-between items-center h-[120px]`}
+        } text-gray-300 fixed top-0 left-0 w-full z-50 transition-colors duration-300 flex justify-between items-center h-[70px]`}
       >
-        <ul className="md:pl-20 pl-10 flex items-center justify-start h-full space-x-15 xl:space-x-20">
+        <ul className="md:pl-20 pl-10 flex items-center justify-start h-full space-x-15 xl:space-x-10">
           {logo && (
             <li className="flex items-center">
-              <Link href="/">
+              <Link href="/" className="pb-1 lg:px-3 xl:px-0 md:px-3 px-2">
                 <Image src={logo} alt="Logo" width={200} height={200} />
               </Link>
             </li>
@@ -120,8 +120,6 @@ export default function NavBarClient({ results }: NavBarClientProps) {
           {rightNavItems?.map((item, index) => renderNavItem(item, index))}
         </ul>
       </nav>
-  
-      <div className="h-[120px]"></div>
     </div>
   );
   


### PR DESCRIPTION
Fixed sizing of nav bar
- reduced height from 120px to 70px 
- reduce button vertical padding by 4px 
- vertically aligned all buttons and added small pb to the logo to get text aligned
- consistent spacing between nav items 

Test passed by @bettybondoc 

<img width="1393" alt="Screenshot 2024-10-14 at 4 26 58 pm" src="https://github.com/user-attachments/assets/0296d3fe-a698-40ef-9ed7-e0250dc81a6c">

**Figure: new nav bar**