### PR TITLE
Improve breadcrumb UI

### DIFF
--- a/components/shared/BlogPostClient.tsx
+++ b/components/shared/BlogPostClient.tsx
@@ -18,7 +18,7 @@ interface BlogPostClientProps {
 
 const BreadCrumbs = ({ title }: { title: string }) => {
     return (
-      <div className="font-light mb-4 text-base inline-flex items-center">
+      <div className="font-light mb-8 text-base inline-flex items-top">
         <Link href="/blog">BLOG</Link> 
         <span className="mx-2">
           <MdOutlineKeyboardArrowRight size={20} />


### PR DESCRIPTION
To fix the breadcrumb alignment + margin.

As per reported by @adamcogan 

> Tiago
> https://yakshaver.ai/docs/recording-work-item-snagit
> 1. See red line on image - should the breadcrumb be top aligned?
> ![image0](https://github.com/user-attachments/assets/d6e1ff5b-69c1-4f79-949c-eaad8b9fb35f)
