### PR TITLE
Fix live editing for /docs and /blogs

### DIFF
--- a/app/[product]/blog/[slug]/page.tsx
+++ b/app/[product]/blog/[slug]/page.tsx
@@ -3,7 +3,8 @@ import InteractiveBackground from "../../../../components/shared/Background/Inte
 import NavBarServer from "../../../../components/shared/NavBarServer";
 import FooterServer from "../../../../components/shared/FooterServer";
 import client from "../../../../tina/__generated__/client";
-import BlogPostClient from "../../../../components/shared/BlogPostClient"; // Import the client component
+import BlogPostClient from "../../../../components/shared/BlogPostClient";
+import { Blogs } from "../../../../tina/__generated__/types";
 
 interface BlogPostProps {
   params: {
@@ -15,12 +16,10 @@ interface BlogPostProps {
 export default async function BlogPost({ params }: BlogPostProps) {
   const { slug, product } = params;
 
-  const data = await getBlogPost(product, slug);
-  if (!data) {
+  const documentData = await getBlogPost(product, slug);
+  if (!documentData) {
     return notFound();
   }
-
-  
 
   return (
     <div className="flex flex-col min-h-screen">
@@ -29,13 +28,9 @@ export default async function BlogPost({ params }: BlogPostProps) {
 
       <div className="flex-grow">
         <BlogPostClient
-          title={data.title}
-          author={data.author || ""}
-          date={data.date || ""}
-          body={data.body}
-          sswPeopleLink={data.sswPeopleLink || ""}
-          readLength={data.readLength || ""}
-          filename={data._sys.filename || ""}
+          query={documentData.query}
+          variables={documentData.variables}
+          pageData={{ blogs: documentData.blogs }}
         />
       </div>
 
@@ -50,13 +45,15 @@ async function getBlogPost(product: string, slug: string) {
       relativePath: `${product}/${slug}.mdx`,
     });
 
-    const blog = res.data?.blogs;
-
-    if (!blog) {
+    if (!res?.data?.blogs) {
       return null;
     }
 
-    return blog;
+    return {
+      query: res.query,
+      variables: res.variables,
+      blogs: res.data.blogs as Blogs,
+    };
   } catch (error) {
     console.error("Error fetching blog post:", error);
     return null;

--- a/app/[product]/docs/[slug]/page.tsx
+++ b/app/[product]/docs/[slug]/page.tsx
@@ -4,6 +4,7 @@ import NavBarServer from "../../../../components/shared/NavBarServer";
 import FooterServer from "../../../../components/shared/FooterServer";
 import client from "../../../../tina/__generated__/client";
 import DocPostClient from "../../../../components/shared/DocPostClient";
+import { Docs } from "../../../../tina/__generated__/types";
 
 interface DocPostProps {
   params: {
@@ -15,12 +16,10 @@ interface DocPostProps {
 export default async function DocPost({ params }: DocPostProps) {
   const { slug, product } = params;
 
-  const data = await getDocPost(product, slug);
-  if (!data) {
+  const documentData = await getDocPost(product, slug);
+  if (!documentData) {
     return notFound();
   }
-
-  
 
   return (
     <div className="flex flex-col min-h-screen">
@@ -29,10 +28,9 @@ export default async function DocPost({ params }: DocPostProps) {
 
       <div className="flex-grow">
         <DocPostClient
-          title={data.title}
-          date={data.date || ""}
-          body={data.body}
-          filename={data._sys.filename || ""}
+          query={documentData.query}
+          variables={documentData.variables}
+          pageData={{ docs: documentData.docs }} 
         />
       </div>
 
@@ -47,13 +45,15 @@ async function getDocPost(product: string, slug: string) {
       relativePath: `${product}/${slug}.mdx`,
     });
 
-    const docs = res.data?.docs;
-
-    if (!docs) {
+    if (!res?.data?.docs) {
       return null;
     }
 
-    return docs;
+    return {
+      query: res.query,
+      variables: res.variables,
+      docs: res.data.docs as Docs,
+    };
   } catch (error) {
     console.error("Error fetching doc post:", error);
     return null;

--- a/components/shared/Blocks/Features.tsx
+++ b/components/shared/Blocks/Features.tsx
@@ -53,7 +53,7 @@ export const featureComponents: Components<Record<string, unknown>> = {
 };
 
 const FeatureBlock = ({ feature }: { feature: FeatureItem }) => {
-  console.log(feature);
+  
   const renderMedia = () => {
     if (feature.media && feature.media.length > 0) {
       const mediaItem = feature.media[0];

--- a/components/shared/BlogPostClient.tsx
+++ b/components/shared/BlogPostClient.tsx
@@ -1,73 +1,84 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 "use client";
 
 import Link from "next/link";
 import { MdOutlineKeyboardArrowRight } from "react-icons/md";
-import { TinaMarkdown, TinaMarkdownContent } from "tinacms/dist/rich-text"; // Assuming TinaMarkdown is used for rendering markdown content
+import { TinaMarkdown } from "tinacms/dist/rich-text";
 import { DocAndBlogMarkdownStyle } from "./DocAndBlogMarkdownStyle";
+import { useTina } from "tinacms/dist/react";
+import { Blogs } from "../../tina/__generated__/types";
 
 interface BlogPostClientProps {
-  title: string;
-  author: string;
-  date: string;
-  body: TinaMarkdownContent;
-  sswPeopleLink?: string;
-  readLength: string;
-  filename: string;
+  query: string;
+  variables: object;
+  pageData: { blogs: Blogs };
 }
 
 const BreadCrumbs = ({ title }: { title: string }) => {
-    return (
-      <div className="font-light mb-8 text-base inline-flex items-top">
-        <Link className="underline cursor-pointer" href="/blog">BLOG</Link> 
-        <span className="mx-2">
-          <MdOutlineKeyboardArrowRight size={20} />
-        </span>
-        <span>{title.toUpperCase()}</span>
-      </div>
-    );
-  };
+  return (
+    <div className="font-light mb-8 text-base inline-flex items-top">
+      <Link className="underline cursor-pointer" href="/blog">
+        BLOG
+      </Link>
+      <span className="mx-2">
+        <MdOutlineKeyboardArrowRight size={20} />
+      </span>
+      <span>{title.toUpperCase()}</span>
+    </div>
+  );
+};
+
 export default function BlogPostClient({
-  title,
-  author,
-  date,
-  body,
-  sswPeopleLink,
-  readLength,
-  
+  query,
+  variables,
+  pageData,
 }: BlogPostClientProps) {
+  const { data } = useTina<{ blogs: Blogs }>({
+    query,
+    variables,
+    data: pageData,
+  });
+
+  
+
+  if (!data?.blogs) {
+    return <p className="text-center text-white">No content available.</p>;
+  }
+
+  const { title, date, sswPeopleLink, readLength, author, body } = data.blogs;
+
+  
+  const parsedDate = date ? new Date(date) : null;
+  const formattedDate =
+    parsedDate && !isNaN(parsedDate.getTime())
+      ? `${parsedDate.getDate()} ${parsedDate.toLocaleString("default", { month: "long" })} ${parsedDate.getFullYear()}`
+      : "Unknown Date";
 
   return (
-    <>
-      <div className="p-4 lg:pt-32 md:pt-20 mt-20 font-semibold max-w-3xl mx-auto text-white">
-        <BreadCrumbs title={title} />
-        <h2 className="text-3xl mb-2 tracking-wide">{title}</h2>
+    <div className="p-4 lg:pt-32 md:pt-20 mt-20 font-semibold max-w-3xl mx-auto text-white">
+      <BreadCrumbs title={title} />
+      <h2 className="text-3xl mb-2 tracking-wide">{title}</h2>
 
-        <div className="text-sm font-light text-gray-300 uppercase mb-4">
-          <span>
-            by{" "}
-            {sswPeopleLink ? (
-              <Link target="_blank" href={sswPeopleLink} className="underline">
-                {author}
-              </Link>
-            ) : (
-              <span>{author}</span>
-            )}
-          </span>
+      <div className="text-sm font-light text-gray-300 uppercase mb-4">
+        <span>
+          by{" "}
+          {sswPeopleLink ? (
+            <Link target="_blank" href={sswPeopleLink} className="underline">
+              {author}
+            </Link>
+          ) : (
+            <span>{author}</span>
+          )}
+        </span>
 
-          <div>
-            <span>{`${new Date(date).getDate()} ${new Date(date).toLocaleString(
-              "default",
-              { month: "long" }
-            )} ${new Date(date).getFullYear()}`}</span>
-            <span>{` | ${readLength}`}</span>
-          </div>
-        </div>
-
-        <div className="text-base font-light lg:prose-xl">
-          <TinaMarkdown content={body} components={DocAndBlogMarkdownStyle} />
+        <div>
+          <span>{formattedDate}</span>
+          <span>{` | ${readLength}`}</span>
         </div>
       </div>
-    </>
+
+      <div className="text-base font-light lg:prose-xl">
+        <TinaMarkdown content={body ?? { type: "root", children: [] }} components={DocAndBlogMarkdownStyle} />
+      </div>
+    </div>
   );
 }

--- a/components/shared/DocPostClient.tsx
+++ b/components/shared/DocPostClient.tsx
@@ -1,57 +1,71 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-"use client";
+'use client';
 
-import Link from "next/link";
-import { MdOutlineKeyboardArrowRight } from "react-icons/md";
-import { TinaMarkdown, TinaMarkdownContent } from "tinacms/dist/rich-text"; // Assuming TinaMarkdown is used for rendering markdown content
-import { DocAndBlogMarkdownStyle } from "./DocAndBlogMarkdownStyle";
+import Link from 'next/link';
+import { MdOutlineKeyboardArrowRight } from 'react-icons/md';
+import { TinaMarkdown } from 'tinacms/dist/rich-text';
+import { DocAndBlogMarkdownStyle } from './DocAndBlogMarkdownStyle';
+import { useTina } from 'tinacms/dist/react';
+import { Docs } from '../../tina/__generated__/types';
 
 interface DocPostClientProps {
-  title: string;
-  date: string;
-  body: TinaMarkdownContent;
-  filename: string;
+  query: string;
+  variables: Record<string, unknown>;
+  pageData: { docs: Docs };
 }
 
 const BreadCrumbs = ({ title }: { title: string }) => {
-    return (
-      <div className="font-light mb-8 text-base inline-flex items-top">
-        <Link className="underline cursor-pointer" href="/docs">DOCS</Link> 
-        <span className="mx-2">
-          <MdOutlineKeyboardArrowRight size={20} />
-        </span>
-        <span>{title.toUpperCase()}</span>
-      </div>
-    );
-  };
-export default function DocPostClient({
-  title,
-  date,
-  body,
-  
+  return (
+    <div className="font-light mb-8 text-base inline-flex items-top">
+      <Link className="underline cursor-pointer" href="/docs">
+        DOCS
+      </Link>
+      <span className="mx-2">
+        <MdOutlineKeyboardArrowRight size={20} />
+      </span>
+      <span>{title.toUpperCase()}</span>
+    </div>
+  );
+};
 
-  
+export default function DocPostClient({
+  query,
+  variables,
+  pageData,
 }: DocPostClientProps) {
+  const { data } = useTina<{ docs: Docs }>({
+    query,
+    variables,
+    data: pageData,
+  });
+
+  console.log('Fetched data:', data);
+
+  if (!data?.docs) {
+    return <p className="text-center text-white">No content available.</p>;
+  }
+
+  const { title, date, body } = data.docs;
+
+  // Ensure the date is valid before formatting
+  const parsedDate = date ? new Date(date) : null;
+  const formattedDate = parsedDate && !isNaN(parsedDate.getTime()) 
+    ? `${parsedDate.getDate()} ${parsedDate.toLocaleString('default', { month: 'long' })} ${parsedDate.getFullYear()}`
+    : 'Unknown Date';
 
   return (
-    <>
-      <div className="p-4 lg:pt-32 md:pt-32 mt-20 font-semibold max-w-3xl mx-auto text-white">
-        <BreadCrumbs title={title} />
-        <h2 className="text-3xl mb-2 tracking-wide">{title}</h2>
+    <div className="p-4 lg:pt-32 md:pt-32 mt-20 font-semibold max-w-3xl mx-auto text-white">
+      <BreadCrumbs title={title} />
+      <h2 className="text-3xl mb-2 tracking-wide">{title}</h2>
 
-        <div className="text-sm font-light text-gray-300 uppercase mb-4">
-          <div>
-            <span>{`${new Date(date).getDate()} ${new Date(date).toLocaleString(
-              "default",
-              { month: "long" }
-            )} ${new Date(date).getFullYear()}`}</span>
-          </div>
-        </div>
-
-        <div className="text-base font-light lg:prose-xl">
-          <TinaMarkdown content={body} components={DocAndBlogMarkdownStyle}/>
+      <div className="text-sm font-light text-gray-300 uppercase mb-4">
+        <div>
+          <span>{formattedDate}</span>
         </div>
       </div>
-    </>
+
+      <div className="text-base font-light lg:prose-xl">
+        <TinaMarkdown content={body ?? { type: 'root', children: [] }} components={DocAndBlogMarkdownStyle} />
+      </div>
+    </div>
   );
 }

--- a/components/shared/DocPostClient.tsx
+++ b/components/shared/DocPostClient.tsx
@@ -38,7 +38,7 @@ export default function DocPostClient({
     data: pageData,
   });
 
-  console.log('Fetched data:', data);
+  
 
   if (!data?.docs) {
     return <p className="text-center text-white">No content available.</p>;

--- a/components/shared/DocPostClient.tsx
+++ b/components/shared/DocPostClient.tsx
@@ -9,7 +9,7 @@ import { Docs } from '../../tina/__generated__/types';
 
 interface DocPostClientProps {
   query: string;
-  variables: Record<string, unknown>;
+  variables: object;
   pageData: { docs: Docs };
 }
 

--- a/components/shared/FooterClient.tsx
+++ b/components/shared/FooterClient.tsx
@@ -61,7 +61,7 @@ export default function FooterClient({ results }: FooterClientProps) {
                   href={item.footerItemLink ?? "#"}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex items-center space-x-2 text-lg md:text-2xl"
+                  className="flex items-center space-x-2 text-lg md:text-2xl hover:-translate-y-1 animation ease-in-out duration-300"
                 >
                   {item.footerItemIcon && iconMap[item.footerItemIcon]}
                 </a>


### PR DESCRIPTION
Re-implemented the `useTina` hook to allow for live editing with the TIna client across all pages (targeting the /docs/<slug> and /blogs/<slug> pages) 