### PR TITLE
drop text size by 1 for mobile to fit for smaller mobile devices

### DIFF
--- a/components/shared/Blocks/Features.tsx
+++ b/components/shared/Blocks/Features.tsx
@@ -126,7 +126,7 @@ const FeatureBlock = ({ feature }: { feature: FeatureItem }) => {
       }  pb-10 lg:pb-0 3xl:px-20`}
     >
       <div className="w-full flex flex-col gap-2 xl:pl-20">
-        <div className="flex flex-wrap items-center text-3xl lg:text-4xl text-white font-semibold">
+        <div className="flex flex-wrap items-center text-2xl md:text-3xl lg:text-4xl text-white font-semibold">
           <div className="view-mode-1 block md:hidden lg:block">
             {/* First line: Headline (always on the first line) */}
             <div className="w-full md:w-auto lg:w-full xl:w-auto flex items-center">


### PR DESCRIPTION
for the common phone size (w-390px) the hero was blocking weirdly onto two lines - dropping the text size by one allows the spacing to fit better on the 360-390px phones. 

![IMG_579C8336B759-1](https://github.com/user-attachments/assets/db8cf4af-a738-400a-9efb-dcd327e69c6b)

**Figure: Mobile before**

![Screenshot 2025-03-05 at 10 50 33 am](https://github.com/user-attachments/assets/3e325971-aacb-475a-8aa2-ce88f2e090ab)

**Figure: Mobile After**