### PR TITLE
Add revalidation to docs page to enforce content updates

### DIFF
--- a/app/[product]/docs/[slug]/page.tsx
+++ b/app/[product]/docs/[slug]/page.tsx
@@ -39,6 +39,9 @@ export default async function DocPost({ params }: DocPostProps) {
   );
 }
 
+// Add revalidation - page wouldn't update although GraphQL was updated. TODO: remove this once @wicksipedia created the global revalidation route.
+export const revalidate = 600;
+
 async function getDocPost(product: string, slug: string) {
   try {
     const res = await client.queries.docs({


### PR DESCRIPTION
As discussed with @wicksipedia, adding revalidation logic to force page update the content. will be removed later when @wicksipedia creates revalidation logic which automatically triggers.