### PR TITLE
EagleEye Move article from blog to docs

### DIFF
--- a/content/docs/EagleEye/how-to-add-a-new-tag.mdx
+++ b/content/docs/EagleEye/how-to-add-a-new-tag.mdx
@@ -4,10 +4,7 @@ seo:
   description: >-
     Learn how to create a new tag in the EagleEye portal and sync the data to see the updated tag in action.
 title: How to Add a New Tag
-date: "2025-03-11T13:00:00.000Z"
-author: Luke Mao
-sswPeopleLink: "https://www.ssw.com.au/people/luke-mao/"
-readLength: 1 minute
+date: "2025-03-13T13:00:00.000Z"
 ---
 
 ## Step 1: Create a New Tag
@@ -20,7 +17,7 @@ readLength: 1 minute
 
 > **Tip for AI Tags**: Ensure you test the prompt and response to verify the tag is working as expected.
 
-3. Click **"Create"** to save the tag.
+4. Click **"Create"** to save the tag.
 
 ## Step 2: Sync Data
 

--- a/content/navBars/EagleEye/EagleEye-NavigationBar.json
+++ b/content/navBars/EagleEye/EagleEye-NavigationBar.json
@@ -7,6 +7,11 @@
       "_template": "stringItem"
     },
     {
+      "label": "Docs",
+      "href": "/docs",
+      "_template": "stringItem"
+    },
+    {
       "label": "Videos",
       "href": "https://www.youtube.com/@SSWEagleEye",
       "_template": "stringItem"


### PR DESCRIPTION
This pull request includes changes to the EagleEye documentation and navigation bar. The most important changes include renaming and updating metadata in the documentation file and adding a new link to the navigation bar.

Documentation updates:

* [`content/docs/EagleEye/how-to-add-a-new-tag.mdx`](diffhunk://#diff-9af05c6af37d1c01a3c6f5e35bb7ec14049222747d913c69e22c06c44638664eL7-R7): Renamed from `content/blogs/EagleEye/how-to-add-a-new-tag.mdx`, updated the `date` field, and corrected a step number in the instructions. [[1]](diffhunk://#diff-9af05c6af37d1c01a3c6f5e35bb7ec14049222747d913c69e22c06c44638664eL7-R7) [[2]](diffhunk://#diff-9af05c6af37d1c01a3c6f5e35bb7ec14049222747d913c69e22c06c44638664eL23-R20)

Navigation bar update:

* [`content/navBars/EagleEye/EagleEye-NavigationBar.json`](diffhunk://#diff-ba46f1abcdb9b103dbe623d028d6f134ce87d3b21eb8e900985be88ce74477aaR9-R13): Added a new "Docs" link to the navigation bar.