### PR TITLE
Add generateStaticParams functions for pages, blogs, and docs

### DIFF
--- a/app/[product]/[filename]/page.tsx
+++ b/app/[product]/[filename]/page.tsx
@@ -18,6 +18,14 @@ export async function generateMetadata({ params }: FilePageProps) {
   return metadata;
 }
 
+export async function generateStaticParams() {
+  const sitePosts = await client.queries.pagesConnection({});
+  return sitePosts.data.pagesConnection?.edges?.map((post) => ({
+    filename: post?.node?._sys.filename,
+    product: post?.node?._sys.breadcrumbs[0]
+  })) || []
+}
+
 export default async function FilePage({ params }: FilePageProps) {
   const { product, filename } = params;
 

--- a/app/[product]/blog/[slug]/page.tsx
+++ b/app/[product]/blog/[slug]/page.tsx
@@ -35,6 +35,15 @@ export async function generateMetadata({ params }: BlogPostProps) {
   }
 }
 
+
+export async function generateStaticParams() {
+  const sitePosts = await client.queries.blogsConnection({});
+  return sitePosts.data.blogsConnection?.edges?.map((post) => ({
+    slug: post?.node?._sys.filename,
+    product: post?.node?._sys.breadcrumbs[0]
+  })) || []
+}
+
 export default async function BlogPost({ params }: BlogPostProps) {
   const { slug, product } = params;
 

--- a/app/[product]/blog/page.tsx
+++ b/app/[product]/blog/page.tsx
@@ -4,6 +4,7 @@ import InteractiveBackground from "../../../components/shared/Background/Interac
 import NavBarServer from "../../../components/shared/NavBarServer";
 import FooterServer from "../../../components/shared/FooterServer";
 import BlogIndexClient from "../../../components/shared/BlogIndexClient";
+import client from "../../../tina/__generated__/client";
 
 interface BlogIndex {
   params: { product: string };
@@ -11,7 +12,7 @@ interface BlogIndex {
 
 export async function generateMetadata({ params }: BlogIndex) {
   const { product } = params;
-  return{
+  return {
     title: `${product} Blogs`,
     description: `Find out more about ${product}, the latest news and updates posted on our blog.`,
     openGraph: {
@@ -21,6 +22,16 @@ export async function generateMetadata({ params }: BlogIndex) {
     },
   }
 }
+
+
+export async function generateStaticParams() {
+  const sitePosts = await client.queries.blogsConnection({});
+  return sitePosts.data.blogsConnection?.edges?.map((post) => ({
+    product: post?.node?._sys.breadcrumbs[0]
+  })) || []
+}
+
+
 
 export default async function BlogIndex({ params }: BlogIndex) {
   const { product } = params;

--- a/app/[product]/docs/[slug]/page.tsx
+++ b/app/[product]/docs/[slug]/page.tsx
@@ -22,9 +22,16 @@ export async function generateMetadata({ params }: DocPostProps) {
   return metadata;
 }
 
+export async function generateStaticParams() {
+  const sitePosts = await client.queries.docsConnection({});
+  return sitePosts.data.docsConnection?.edges?.map((post) => ({
+    slug: post?.node?._sys.filename,
+    product: post?.node?._sys.breadcrumbs[0]
+  })) || []
+}
+
 export default async function DocPost({ params }: DocPostProps) {
   const { slug, product } = params;
-
   const documentData = await getDocPost(product, slug);
 
   if (!documentData) {

--- a/app/[product]/docs/page.tsx
+++ b/app/[product]/docs/page.tsx
@@ -4,6 +4,7 @@ import NavBarServer from "../../../components/shared/NavBarServer";
 import FooterServer from "../../../components/shared/FooterServer";
 import DocsIndexClient from "../../../components/shared/DocsIndexClient";
 import { getDocsForProduct } from "../../../utils/fetchDocs";
+import client from "../../../tina/__generated__/client";
 
 interface BlogIndex {
   params: { product: string };
@@ -11,7 +12,7 @@ interface BlogIndex {
 
 export async function generateMetadata({ params }: BlogIndex) {
   const { product } = params;
-  return{
+  return {
     title: `${product} Docs`,
     description: `Find out more about ${product}, guides and documentation`,
     openGraph: {
@@ -23,13 +24,21 @@ export async function generateMetadata({ params }: BlogIndex) {
 }
 
 
+export async function generateStaticParams() {
+  const sitePosts = await client.queries.docsConnection({});
+  return sitePosts.data.docsConnection?.edges?.map((post) => ({
+    product: post?.node?._sys.breadcrumbs[0]
+  })) || []
+}
+
+
 export default async function DocsIndex({ params }: BlogIndex) {
   const { product } = params;
 
   try {
     const docs = await getDocsForProduct(product);
 
-    
+
 
     if (!docs) {
       return notFound();

--- a/app/[product]/page.tsx
+++ b/app/[product]/page.tsx
@@ -15,6 +15,14 @@ export async function generateMetadata({ params }: ProductPageProps) {
   return metadata;
 }
 
+
+export async function generateStaticParams() {
+  const sitePosts = await client.queries.pagesConnection({});
+  return sitePosts.data.pagesConnection?.edges?.map((post) => ({
+    product: post?.node?._sys.breadcrumbs[0]
+  })) || []
+}
+
 export default async function ProductPage({ params }: ProductPageProps) {
   const product = params.product;
 
@@ -32,9 +40,8 @@ export default async function ProductPage({ params }: ProductPageProps) {
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: `${
-              productData?.data.pages.seo?.googleStructuredData ?? {}
-            }`,
+            __html: `${productData?.data.pages.seo?.googleStructuredData ?? {}
+              }`,
           }}
         />
       )}

--- a/components/shared/FooterServer.tsx
+++ b/components/shared/FooterServer.tsx
@@ -6,9 +6,14 @@ interface FooterServerProps {
 }
 
 export default async function FooterServer({ product }: FooterServerProps) {
-  const { data } = await client.queries.footer({
-    relativePath: `${product}/${product}-Footer.json`,
-  });
-
-  return <FooterClient results={data} />;
-}
+  let footerData = null
+  try {
+    const { data } = await client.queries.footer({
+      relativePath: `${product}/${product}-Footer.json`,
+    })
+    footerData = data
+  } catch {
+    // We don't care about this... for the moment
+  }
+  return <FooterClient results={footerData} />;
+} 


### PR DESCRIPTION
- Adds SSG to SSW Products - general site speedup! 



https://github.com/user-attachments/assets/d9032a36-9947-43c9-957a-bbaa87d3c187


**Figure: Page Load Improved as its not being Server Rendered anymore!** 

```
 ✓ Generating static pages (32/32)
 ✓ Collecting build traces
 ✓ Finalizing page optimization

Route (app)                                       Size     First Load JS
┌ ○ /_not-found                                   878 B          88.4 kB
├ ● /[product]                                    240 B          1.44 MB
├   ├ /EagleEye
├   ├ /TimePro
├   └ /YakShaver
├ ● /[product]/[filename]                         425 B          1.44 MB
├   ├ /EagleEye/home
├   ├ /TimePro/home
├   ├ /YakShaver/about
├   └ [+2 more paths]
├ ● /[product]/blog                               1.52 kB         118 kB
├   ├ /EagleEye/blog
├   └ /YakShaver/blog
├ ● /[product]/blog/[slug]                        956 B           114 kB
├   ├ /EagleEye/blog/what-is-eagleeye
├   ├ /YakShaver/blog/ai-at-comptia
├   ├ /YakShaver/blog/new-support-macos
├   └ [+2 more paths]
├ ● /[product]/docs                               1.51 kB         118 kB
├   ├ /EagleEye/docs
├   └ /YakShaver/docs
├ ● /[product]/docs/[slug]                        871 B           114 kB
├   ├ /EagleEye/docs/how-to-add-a-new-tag
├   ├ /YakShaver/docs/frequently-asked-questions
├   ├ /YakShaver/docs/how-to-use-yakshaver
├   └ [+7 more paths]
└ ○ /api/leaderboard                              0 B                0 B
+ First Load JS shared by all                     87.5 kB
  ├ chunks/23-9c66f0c3f5f75866.js                 31.7 kB
  ├ chunks/fd9d1056-e907dfdc847aaf13.js           53.7 kB
  └ other shared chunks (total)                   2.09 kB


ƒ Middleware                                      26.5 kB

○  (Static)  prerendered as static content
●  (SSG)     prerendered as static HTML (uses getStaticProps)
```