### PR TITLE
Fixed UI for rendering navigation group items

### DIFF
--- a/components/shared/NavBarClient.tsx
+++ b/components/shared/NavBarClient.tsx
@@ -7,6 +7,9 @@ import { BookingButton } from "./Blocks/BookingButton";
 import Link from "next/link";
 import { HiOutlineBars3 } from "react-icons/hi2";
 import { CgClose } from "react-icons/cg";
+import { IoCaretDown } from "react-icons/io5";
+import { FaChevronRight } from "react-icons/fa6";
+import { FaExternalLinkAlt } from "react-icons/fa";
 
 interface NavBarClientProps {
   results: NavigationBarQuery | null;
@@ -37,6 +40,7 @@ export default function NavBarClient({ results }: NavBarClientProps) {
   const logo = navigationBar?.Logo;
 
   const renderNavItem = (item: any, index: number) => {
+    console.log(item);
     switch (item?.__typename) {
       case "NavigationBarLeftNavItemStringItem":
       case "NavigationBarRightNavItemStringItem":
@@ -53,18 +57,38 @@ export default function NavBarClient({ results }: NavBarClientProps) {
       case "NavigationBarLeftNavItemGroupOfStringItems":
       case "NavigationBarRightNavItemGroupOfStringItems":
         return (
-          <li key={index} className="flex items-center group relative">
-            <span className="cursor-pointer">{item.label}</span>
-            <ul className="absolute top-full left-0 bg-white text-black hidden group-hover:block mt-2 space-y-1 p-2 rounded shadow-lg">
-              {item.items?.map((subItem: any, subIndex: number) => (
-                <li key={subIndex}>
-                  <Link href={subItem.href}>
-                    {subItem.label}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </li>
+          <>
+            {/* For lg screens and above - show dropdown */}
+            <li key={index} className="hidden lg:flex items-center group relative px-2 lg:px-3">
+              <span className="cursor-pointer flex items-center gap-2">{item.label.toUpperCase()} <FaChevronRight className="text-red-500 text-sm group-hover:rotate-90 transition-all duration-300"/></span>
+              <div className="absolute top-full left-0 opacity-0 invisible group-hover:opacity-100 group-hover:visible pt-2 transition-all duration-300">
+                <ul className="bg-black text-[#D1D5DB] border border-white/20 mt-0 space-y-2 p-3 rounded shadow-lg min-w-[150px] z-10">
+                  {item.items?.map((subItem: any, subIndex: number) => (
+                    <li key={subIndex} className="hover:text-white transition-colors flex items-center gap-1">
+                      <Link href={subItem.href} className="block w-full hover:underline underline-offset-4 decoration-[#CC4141] flex items-center gap-1">
+                        {subItem.label}
+                        {subItem.href && (subItem.href.startsWith('http://') || subItem.href.startsWith('https://')) && (
+                          <FaExternalLinkAlt className="text-xs text-red-500" />
+                        )}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </li>
+            
+            {/* For md screens and below - show all subitems directly */}
+            {item.items?.map((subItem: any, subIndex: number) => (
+              <li key={`${index}-${subIndex}`} className="lg:hidden flex items-center px-2 py-1">
+                <Link href={subItem.href} className="hover:underline underline-offset-4 decoration-[#CC4141] text-md flex items-center gap-1">
+                  {subItem.label}
+                  {subItem.href && (subItem.href.startsWith('http://') || subItem.href.startsWith('https://')) && (
+                    <FaExternalLinkAlt className="text-xs text-red-500 opacity-50" />
+                  )}
+                </Link>
+              </li>
+            ))}
+          </>
         );
       case "NavigationBarLeftNavItemModalButton":
       case "NavigationBarRightNavItemModalButton":

--- a/components/shared/NavBarClient.tsx
+++ b/components/shared/NavBarClient.tsx
@@ -39,7 +39,6 @@ export default function NavBarClient({ results }: NavBarClientProps) {
   const logo = navigationBar?.Logo;
 
   const renderNavItem = (item: any, index: number) => {
-    console.log(item);
     switch (item?.__typename) {
       case "NavigationBarLeftNavItemStringItem":
       case "NavigationBarRightNavItemStringItem":

--- a/components/shared/NavBarClient.tsx
+++ b/components/shared/NavBarClient.tsx
@@ -7,7 +7,6 @@ import { BookingButton } from "./Blocks/BookingButton";
 import Link from "next/link";
 import { HiOutlineBars3 } from "react-icons/hi2";
 import { CgClose } from "react-icons/cg";
-import { IoCaretDown } from "react-icons/io5";
 import { FaChevronRight } from "react-icons/fa6";
 import { FaExternalLinkAlt } from "react-icons/fa";
 

--- a/content/navBars/YakShaver/YakShaver-NavigationBar.json
+++ b/content/navBars/YakShaver/YakShaver-NavigationBar.json
@@ -22,9 +22,18 @@
       "_template": "stringItem"
     },
     {
-      "label": "Roadmap",
-      "href": "/roadmap",
-      "_template": "stringItem"
+      "label": "COMMUNITY",
+      "items": [
+        {
+          "label": "ROADMAP",
+          "href": "/roadmap"
+        },
+        {
+          "label": "DISCORD",
+          "href": "https://discord.gg/Jp9dyxKFjR"
+        }
+      ],
+      "_template": "groupOfStringItems"
     },
     {
       "label": "Videos",


### PR DESCRIPTION
As per https://github.com/SSWConsulting/SSW.YakShaver/issues/1642 we wanted to be able to render group items in the nav bar, this PR updates the nav bar to allow for this and fixes the UI for it too

<img width="1327" alt="Screenshot 2025-03-24 at 11 47 20 am" src="https://github.com/user-attachments/assets/32d7c1d5-5497-4b79-8aae-9cd3f3b520d0" />

**Group Items large nav bar**

<img width="920" alt="Screenshot 2025-03-24 at 11 49 26 am" src="https://github.com/user-attachments/assets/8233218d-a187-477d-936b-9371bd6e2351" />

**Group items small nav bar**