### PR TITLE
Improve user experience on EagleEye video and action buttons

### DIFF
--- a/components/shared/Blocks/ActionsButton.tsx
+++ b/components/shared/Blocks/ActionsButton.tsx
@@ -25,6 +25,7 @@ export const ActionButton = ({
     <Link
       href={action.url}
       className={`whitespace-nowrap inline-flex items-center justify-center rounded-lg ${className} ${action.variant} ${action.size} hover:opacity-80 transition-opacity duration-200 font-semibold`}
+      target="_blank"
     >
       {action.label}
     </Link>

--- a/content/pages/EagleEye/home.json
+++ b/content/pages/EagleEye/home.json
@@ -22,9 +22,8 @@
           ],
           "media": [
             {
-              "image": "/EagleEye/Thumbnail.jpg",
-              "src": "https://www.youtube.com/watch?v=-7c6uagBBBM",
-              "_template": "thumbnailToExternalLink"
+              "src": "https://www.youtube.com/embed/-7c6uagBBBM?si=V5ZP_lCtpgC3cOqi",
+              "_template": "externalVideo"
             }
           ],
           "isReversed": false


### PR DESCRIPTION
Originated from PBI https://github.com/SSWConsulting/SSW.EagleEye/issues/1059

1. Use embedded YouTube video on EagleEye home page
2. Update action button to open in new tab. This has impact on :
  a. EagleEye home page - "BOOK A DEMO" button
  b. EagleEye home page - "SCHEDULE CALL" button
  c. YakShaver about page - "SCHEDULE CALL" button