### PR TITLE
🐛 Card and author | move author to separate line

### DIFF
--- a/components/shared/BlogIndexClient.tsx
+++ b/components/shared/BlogIndexClient.tsx
@@ -135,10 +135,8 @@ const FeaturedArticle = ({
                     {featuredBlog?.title}
                   </h3>
                 </Link>
-                {/* <div className="flex sm:flex-row gap-3 flex-col text-sm md:text-base"> */}
                 <Author {...featuredBlog} />
                 <ArticleMetadata className="" {...featuredBlog} />
-                {/* </div> */}
 
                 <section className="text-gray-300 text-sm md:text-base mb-6 line-clamp-2 md:line-clamp-none">
                   <TinaMarkdown
@@ -289,7 +287,6 @@ const RecentArticles = ({
                         {post?.title}
                       </h3>
                     </Link>
-                    {/* <div className="flex text-sm flex-col sm:flex-row gap-3 sm:items-center "> */}
                     <Author
                       author={edge?.node?.author}
                       authorImage={edge?.node?.authorImage}
@@ -300,7 +297,6 @@ const RecentArticles = ({
                       date={edge?.node?.date}
                       readLength={edge?.node?.readLength}
                     />
-                    {/* </div> */}
 
                     <section className="text-gray-300 text-sm mb-4 line-clamp-2">
                       <TinaMarkdown content={post?.body} />

--- a/components/shared/BlogIndexClient.tsx
+++ b/components/shared/BlogIndexClient.tsx
@@ -135,10 +135,10 @@ const FeaturedArticle = ({
                     {featuredBlog?.title}
                   </h3>
                 </Link>
-                <div className="flex sm:flex-row gap-3 flex-col text-sm md:text-base">
-                  <Author {...featuredBlog} />
-                  <ArticleMetadata className="" {...featuredBlog} />
-                </div>
+                {/* <div className="flex sm:flex-row gap-3 flex-col text-sm md:text-base"> */}
+                <Author {...featuredBlog} />
+                <ArticleMetadata className="" {...featuredBlog} />
+                {/* </div> */}
 
                 <section className="text-gray-300 text-sm md:text-base mb-6 line-clamp-2 md:line-clamp-none">
                   <TinaMarkdown
@@ -289,18 +289,18 @@ const RecentArticles = ({
                         {post?.title}
                       </h3>
                     </Link>
-                    <div className="flex text-sm flex-col sm:flex-row gap-3 sm:items-center ">
-                      <Author
-                        author={edge?.node?.author}
-                        authorImage={edge?.node?.authorImage}
-                        sswPeopleLink={edge?.node?.sswPeopleLink}
-                      />
-                      <ArticleMetadata
-                        className="h-fit"
-                        date={edge?.node?.date}
-                        readLength={edge?.node?.readLength}
-                      />
-                    </div>
+                    {/* <div className="flex text-sm flex-col sm:flex-row gap-3 sm:items-center "> */}
+                    <Author
+                      author={edge?.node?.author}
+                      authorImage={edge?.node?.authorImage}
+                      sswPeopleLink={edge?.node?.sswPeopleLink}
+                    />
+                    <ArticleMetadata
+                      className="h-fit"
+                      date={edge?.node?.date}
+                      readLength={edge?.node?.readLength}
+                    />
+                    {/* </div> */}
 
                     <section className="text-gray-300 text-sm mb-4 line-clamp-2">
                       <TinaMarkdown content={post?.body} />


### PR DESCRIPTION
CC: @hveraus 

I've moved the author name on the blog index page to a separate line so that the name and date don't get smudged when the name is too long.

sorry @bettybondoc  ☹️

![image](https://github.com/user-attachments/assets/1df6687a-1e05-46d6-9234-15277daf4a0d)
**Figure: Fixes this**