### PR TITLE
change the roi calculator link to main page

### DIFF
--- a/content/blogs/YakShaver/how-much-time-does-yakshaver-save.mdx
+++ b/content/blogs/YakShaver/how-much-time-does-yakshaver-save.mdx
@@ -9,7 +9,7 @@ sswPeopleLink: 'https://www.ssw.com.au/people/steven-qiang/'
 readLength: 2 min
 ---
 
-Creating a high-quality work item, bug report, or PBI that meets the Definition of Ready in a Scrum project takes ***30 minutes on average\****. This includes writing clear descriptions, acceptance criteria, and relevant details, along with refinement meetings and collaboration time, which typically account for 30–50% of the total effort. Complex items may take **6+ hours**, especially if they require deep technical discussions or dependencies on other teams.
+Creating a high-quality work item, bug report, or PBI that meets the Definition of Ready in a Scrum project takes ***30 minutes on average***\*. This includes writing clear descriptions, acceptance criteria, and relevant details, along with refinement meetings and collaboration time, which typically account for 30–50% of the total effort. Complex items may take **6+ hours**, especially if they require deep technical discussions or dependencies on other teams.
 
 YakShaver cuts down the time needed to create a Work Item by handling the heavy lifting with AI. Each Work Item saves around 30 minutes on average. This helps teams focus more on refining tasks in meetings and ensures items meet the Definition of Ready faster. Even complex items that require deep discussions or dependencies can be completed in less time, improving overall efficiency and collaboration.
 

--- a/content/blogs/YakShaver/how-much-time-does-yakshaver-save.mdx
+++ b/content/blogs/YakShaver/how-much-time-does-yakshaver-save.mdx
@@ -9,11 +9,11 @@ sswPeopleLink: 'https://www.ssw.com.au/people/steven-qiang/'
 readLength: 2 min
 ---
 
-Creating a high-quality work item, bug report, or PBI that meets the Definition of Ready in a Scrum project takes ***30 ***minutes*** on average\****. This includes writing clear descriptions, acceptance criteria, and relevant details, along with refinement meetings and collaboration time, which typically account for 30–50% of the total effort. Complex items may take **6+ hours**, especially if they require deep technical discussions or dependencies on other teams.
+Creating a high-quality work item, bug report, or PBI that meets the Definition of Ready in a Scrum project takes ***30 minutes on average\****. This includes writing clear descriptions, acceptance criteria, and relevant details, along with refinement meetings and collaboration time, which typically account for 30–50% of the total effort. Complex items may take **6+ hours**, especially if they require deep technical discussions or dependencies on other teams.
 
 YakShaver cuts down the time needed to create a Work Item by handling the heavy lifting with AI. Each Work Item saves around 30 minutes on average. This helps teams focus more on refining tasks in meetings and ensures items meet the Definition of Ready faster. Even complex items that require deep discussions or dependencies can be completed in less time, improving overall efficiency and collaboration.
 
-You can learn how much you can save for your own company by checking out our [ROI Calculator](https://yakshaver.ai/pricing)
+You can learn how much you can save for your own company by checking out our [ROI Calculator](https://yakshaver.ai)
 
 ![](/YakShaver/Blogs/ROI.png)Figure: Our ROI Calculator
 


### PR DESCRIPTION
change the roi calculator link to main page.
The ROI Calculator link was originally directed to Pricing page as Adam want the calculator there, however, it seems not going to happen for now as the discussion with the designers.
- #214 