### PR TITLE
Improve ROI calculator clarity and consistency

### DIFF
--- a/components/shared/Blocks/Calculator.tsx
+++ b/components/shared/Blocks/Calculator.tsx
@@ -181,7 +181,7 @@ const EstimatedSavingsContent = ({
 
   return (
     <div className="w-full flex flex-col space-y-3">
-      <h3 className="text-2xl text-white font-bold">Your ROI with YakShaver</h3>
+      <h3 className="text-2xl text-white font-bold">YakShaver Usage ROI</h3>
       <div className="flex flex-col">
         <p className="text-white/50">Monthly Detailed Work Items</p>
         <p
@@ -192,7 +192,7 @@ const EstimatedSavingsContent = ({
           <span className="flex gap-2 align-baseline items-baseline">
             {isCustomTier
               ? "Enough to fill a warehouse"
-              : `Up to ${itemsAbleToCreate}`}
+              : `${itemsAbleToCreate}`}
           </span>
         </p>
       </div>
@@ -204,7 +204,7 @@ const EstimatedSavingsContent = ({
           </Tooltip>
         </div>
         <p
-          className={`bg-gradient-to-r from-[#e34f4f] via-[#D699FB] to-[#FF778E] bg-clip-text text-transparent font-bold ${
+          className={`text-white font-bold ${
             isCustomTier ? "text-xl" : "text-2xl"
           }`}
         >

--- a/content/pages/YakShaver/home.json
+++ b/content/pages/YakShaver/home.json
@@ -192,7 +192,7 @@
         {
           "tier": "Starter ",
           "description": [
-            "15 Credits per month",
+            "15 credits per month",
             "For individuals"
           ],
           "price": 0,
@@ -209,7 +209,7 @@
         {
           "tier": "Team",
           "description": [
-            "100 Credits per month",
+            "100 credits per month",
             "For growing teams"
           ],
           "price": 39,
@@ -226,7 +226,7 @@
         {
           "tier": "Growth",
           "description": [
-            "500 Credits per month",
+            "500 credits per month",
             "For larger organizations"
           ],
           "price": 189,


### PR DESCRIPTION
﻿> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Resolves https://github.com/SSWConsulting/SSW.YakShaver/issues/1911

> 2. What was changed?

- "Credits" are now "credits"
- Remove the gradient on the hours
- Remove "Up to" in "Up to x" for work items on the calculator
- Reword "Your ROI with YakShaver" to "YakShaver Usage ROI"

![image](https://github.com/user-attachments/assets/29aab223-f64c-4822-bd51-fae75ecc1829)
**Figure: Highlighting the changes**

> 3. Did you do pair or mob programming?

N/A
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
