### PR TITLE
Refactor image properties in BlogCard, Author, BlogIndexClient, BlogPostClient, and BentoBox components to use Tailwind CSS classes for object fitting.

### DIFF
--- a/components/BlogCard.tsx
+++ b/components/BlogCard.tsx
@@ -44,7 +44,7 @@ export const BlogCard = ({
               <Image
                 alt=""
                 fill
-                objectFit="cover"
+                className="object-cover"
                 aria-hidden={true}
                 src={bannerImage}
               />

--- a/components/shared/Author.tsx
+++ b/components/shared/Author.tsx
@@ -17,7 +17,7 @@ const Author = ({
           src={authorImage || "/default-images/Placeholder-profile.png"}
           alt="placeholder blog author"
           fill
-          objectFit="cover"
+          className="object-cover"
         />
       </div>
       <p className="font-medium h-fit">

--- a/components/shared/Blocks/BentoBox/BentoBox.tsx
+++ b/components/shared/Blocks/BentoBox/BentoBox.tsx
@@ -30,7 +30,8 @@ function IconBox({
               src={image || "/svg/github-mark-white.svg"}
               alt="icon"
               layout="fill"
-              objectFit="contain"
+              
+              className="object-contain"
             />
           </div>
         </div>
@@ -69,7 +70,7 @@ function SmAndMdView({ data }: { data: any }) {
           src={"/YakShaver/Arrow-bg.png"}
           alt="yak"
           layout="fill"
-          objectFit="cover"
+          className="object-cover"
           className="h-full w-full flex rounded-xl z-20"
         />
 
@@ -128,7 +129,7 @@ function BeamBox({ data }: { data: any }) {
         src={"/YakShaver/Arrow-bg.png"}
         alt="yak"
         layout="fill"
-        objectFit="cover"
+        className="object-cover"
         className="h-full w-full rounded-xl"
       />
       <div className="absolute inset-0 -bottom-2 flex items-end">
@@ -149,7 +150,7 @@ function PhotoBox({ photo }: { photo: string }) {
         src={photo || "/YakShaver/The-Yak.png"}
         alt="yak"
         layout="fill"
-        objectFit="cover"
+        className="object-cover"
         className="h-full w-full rounded-xl filter grayscale"
       />
     </div>

--- a/components/shared/Blocks/BentoBox/BentoBox.tsx
+++ b/components/shared/Blocks/BentoBox/BentoBox.tsx
@@ -70,8 +70,7 @@ function SmAndMdView({ data }: { data: any }) {
           src={"/YakShaver/Arrow-bg.png"}
           alt="yak"
           layout="fill"
-          className="object-cover"
-          className="h-full w-full flex rounded-xl z-20"
+          className="h-full w-full flex rounded-xl z-20 object-cover"
         />
 
         <div className="pt-14 md:pt-0 flex items-center justify-center h-1/2 sm:h-full w-full sm:w-2/3 z-30 order-first sm:order-last">
@@ -129,8 +128,7 @@ function BeamBox({ data }: { data: any }) {
         src={"/YakShaver/Arrow-bg.png"}
         alt="yak"
         layout="fill"
-        className="object-cover"
-        className="h-full w-full rounded-xl"
+        className="h-full w-full rounded-xl object-cover"
       />
       <div className="absolute inset-0 -bottom-2 flex items-end">
         <AnimatedBeamMultipleOutput data={data} />
@@ -150,8 +148,7 @@ function PhotoBox({ photo }: { photo: string }) {
         src={photo || "/YakShaver/The-Yak.png"}
         alt="yak"
         layout="fill"
-        className="object-cover"
-        className="h-full w-full rounded-xl filter grayscale"
+        className="h-full w-full rounded-xl filter grayscale object-cover"
       />
     </div>
   );

--- a/components/shared/Blocks/TryItNow.tsx
+++ b/components/shared/Blocks/TryItNow.tsx
@@ -181,10 +181,9 @@ const Card = ({ card, key }: CardProps) => {
             card.image.imgHeight && (
               <Image
                 data-tina-field={tinaField(card, "image")}
-                className="bottom-0 w-full absolute"
+                className="bottom-0 w-full absolute object-contain"
                 src={card.image.imgSrc}
                 aria-hidden="true"
-                objectFit="contain"
                 width={card.image.imgWidth}
                 height={card.image.imgHeight}
                 alt={""}

--- a/components/shared/BlogIndexClient.tsx
+++ b/components/shared/BlogIndexClient.tsx
@@ -265,7 +265,7 @@ const Author = ({
           src={authorImage || "/default-images/Placeholder-profile.png"}
           alt="placeholder blog author"
           fill
-          objectFit="cover"
+          className="object-cover"
         />
       </div>
       <p className="font-medium h-fit">

--- a/components/shared/BlogPostClient.tsx
+++ b/components/shared/BlogPostClient.tsx
@@ -99,9 +99,8 @@ export default function BlogPostClient({
         >
           <Image
             alt="alt text"
-            objectFit="cover"
             fill
-            className="rounded-lg mask-b-from-60% mask-b-to-100%"
+            className="object-cover rounded-lg mask-b-from-60% mask-b-to-100%"
             aria-hidden="true"
             src={data.blogs.bannerImage || ""}
           />


### PR DESCRIPTION
Minor bugfix, objectFit="cover" is legacy in Next js and was causing warnings on browser, changed to use tailwind class instead