### PR TITLE
enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Maintain dependencies for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - 'Type: Dependencies'
+    commit-message:
+      prefix: "⬆️ NPM"
+    rebase-strategy: auto
+    ignore:
+      - dependency-name: "yup"


### PR DESCRIPTION
This pull request introduces a new `.github/dependabot.yml` file to configure Dependabot for automated dependency updates. The configuration specifies weekly updates for npm dependencies, includes labeling and commit message customization, and excludes updates for the `yup` package.

Dependency management configuration:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R1-R19): Added Dependabot configuration to automate npm dependency updates on a weekly schedule, with labels, a custom commit message prefix, and an exclusion for the `yup` package.