### PR TITLE
🔍SEO - Add dynamic sitemap generator for all tenants

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,9 @@ In order to do this complete the following steps:
 ## Wanting to use the Middleware for your own site?
 
 We've documented how we use this middleware for our own sites and clients - [Do you know how to use single codebase for multiple domains with TinaCMS and Next.js?](https://www.ssw.com.au/rules/single-codebase-for-multiple-domains-with-tinacm-nextjs/)
+
+## Updating the sitemap
+
+If you are adding a new page using one of the existing [Tina collections](https://tina.io/docs/reference/collections) for the site, you do not need to update the sitemap as it will automatically include the new page.
+
+If you are however adding a new collection for a page template you'll need to update the sitemap returned by `app/sitemap.xml/route.tsx` to include the new collection.

--- a/app/[product]/sitemap.xml/route.ts
+++ b/app/[product]/sitemap.xml/route.ts
@@ -51,7 +51,6 @@ export async function GET(
 
   const allUrls = await getAllUrls(product);
 
-  console.log("allUrls", allUrls.length);
   const sitemap = await buildSitemap(baseUrl, allUrls);
   return new Response(sitemap, {
     status: 200,
@@ -84,7 +83,7 @@ const getAllUrls = async (product: string) => {
   return [
     ...docLinks.map((doc) => `docs/${doc}`),
     ...blogLinks.map((blog) => `blog/${blog}`),
-    ...pageLinks.map((page) => `${page}`),
+    ...pageLinks.filter((page) => page !== "home").map((page) => `${page}`),
     ...privacyPage,
   ];
 };

--- a/app/[product]/sitemap.xml/route.ts
+++ b/app/[product]/sitemap.xml/route.ts
@@ -1,0 +1,124 @@
+import { Product } from "@/types/product-list";
+import client from "@tina/__generated__/client";
+import { SystemInfo } from "@tina/__generated__/types";
+import { tenantHasPrivacyPolicy } from "@utils/privacy";
+import { SitemapStream, streamToPromise } from "sitemap";
+import { Readable } from "stream";
+
+function filterEdgesByTenant<T extends Edges>(connection: T, product: string) {
+  return mapConnection(connection, (acc: Edge[], curr) => {
+    const breadcrumb = curr?.node?._sys.breadcrumbs?.at(0);
+    if (!breadcrumb || breadcrumb !== product) return acc;
+    return [...acc, curr];
+  });
+}
+
+function getSlugsFromCollections<T extends Edges>(edges: T): string[] {
+  if (!edges) return [];
+  return edges.reduce<string[]>((acc, curr) => {
+    const slug = curr?.node?._sys.breadcrumbs?.at(-1);
+    if (!slug) return acc;
+    return [...acc, slug];
+  }, []);
+}
+
+const buildSitemap = async (hostname: string, paths: string[]) => {
+  const links = paths.map((path) => ({
+    url: path,
+    changefreq: "daily",
+    priority: 0.7,
+  }));
+
+  const stream = new SitemapStream({ hostname });
+  const sitemap = await streamToPromise(Readable.from(links).pipe(stream));
+  return sitemap.toString();
+};
+
+export async function GET(
+  request: Request,
+  { params }: { params: { product: string } }
+): Promise<Response> {
+  const product = params.product;
+
+  const hostname = getDomainForTenant(product);
+  if (!hostname) {
+    return new Response(`No tenant found matching parameter \"${product}\"`, {
+      status: 404,
+    });
+  }
+
+  const baseUrl = `https://${hostname}`;
+
+  const allUrls = await getAllUrls(product);
+
+  console.log("allUrls", allUrls.length);
+  const sitemap = await buildSitemap(baseUrl, allUrls);
+  return new Response(sitemap, {
+    status: 200,
+    headers: {
+      "content-Type": "application/xml",
+    },
+  });
+}
+
+const getAllUrls = async (product: string) => {
+  const [allDocs, allPages, allBlogs] = await Promise.all([
+    client.queries.docsConnection(),
+    client.queries.pagesConnection(),
+    client.queries.blogsConnection(),
+  ]);
+
+  const [docLinks, blogLinks, pageLinks] = [
+    allDocs.data.docsConnection.edges,
+    allBlogs.data.blogsConnection.edges,
+    allPages.data.pagesConnection.edges,
+  ].map((collection) => {
+    const filteredCollection = filterEdgesByTenant(collection, product);
+    return getSlugsFromCollections(filteredCollection);
+  });
+
+  const privacyPage = (await tenantHasPrivacyPolicy(product))
+    ? [`privacy`]
+    : [];
+
+  return [
+    ...docLinks.map((doc) => `docs/${doc}`),
+    ...blogLinks.map((blog) => `blog/${blog}`),
+    ...pageLinks.map((page) => `${page}`),
+    ...privacyPage,
+  ];
+};
+
+const getDomainForTenant = (product: string) => {
+  if (!process.env.NEXT_PUBLIC_PRODUCT_LIST)
+    throw new Error("NEXT_PUBLIC_PRODUCT_LIST is not defined");
+  const productList: Product[] = JSON.parse(
+    process.env.NEXT_PUBLIC_PRODUCT_LIST
+  );
+
+  for (const item of productList) {
+    if (item.product === product) {
+      return item.domain;
+    }
+  }
+};
+
+type Edges = Edge[] | null | undefined;
+
+type Edge =
+  | {
+      node?: {
+        _sys: Partial<SystemInfo>;
+      } | null;
+    }
+  | null
+  | undefined;
+function mapConnection<T extends Edges, R>(
+  edges: T,
+  mapFn: (acc: R[], curr: Edge) => R[]
+): R[] {
+  if (!edges) return [];
+  return edges.reduce<R[]>((acc: R[], curr: Edge) => {
+    return mapFn(acc, curr);
+  }, []);
+}

--- a/app/[product]/sitemap.xml/route.ts
+++ b/app/[product]/sitemap.xml/route.ts
@@ -1,38 +1,5 @@
-import { Product } from "@/types/product-list";
-import client from "@tina/__generated__/client";
-import { SystemInfo } from "@tina/__generated__/types";
-import { tenantHasPrivacyPolicy } from "@utils/privacy";
-import { SitemapStream, streamToPromise } from "sitemap";
-import { Readable } from "stream";
-
-function filterEdgesByTenant<T extends Edges>(connection: T, product: string) {
-  return mapConnection(connection, (acc: Edge[], curr) => {
-    const breadcrumb = curr?.node?._sys.breadcrumbs?.at(0);
-    if (!breadcrumb || breadcrumb !== product) return acc;
-    return [...acc, curr];
-  });
-}
-
-function getSlugsFromCollections<T extends Edges>(edges: T): string[] {
-  if (!edges) return [];
-  return edges.reduce<string[]>((acc, curr) => {
-    const slug = curr?.node?._sys.breadcrumbs?.at(-1);
-    if (!slug) return acc;
-    return [...acc, slug];
-  }, []);
-}
-
-const buildSitemap = async (hostname: string, paths: string[]) => {
-  const links = paths.map((path) => ({
-    url: path,
-    changefreq: "daily",
-    priority: 0.7,
-  }));
-
-  const stream = new SitemapStream({ hostname });
-  const sitemap = await streamToPromise(Readable.from(links).pipe(stream));
-  return sitemap.toString();
-};
+import { buildSitemap, getAllUrls } from "@utils/sitemap";
+import { getDomainForTenant } from "@utils/tenancy";
 
 export async function GET(
   request: Request,
@@ -58,66 +25,4 @@ export async function GET(
       "content-Type": "application/xml",
     },
   });
-}
-
-const getAllUrls = async (product: string) => {
-  const [allDocs, allPages, allBlogs] = await Promise.all([
-    client.queries.docsConnection(),
-    client.queries.pagesConnection(),
-    client.queries.blogsConnection(),
-  ]);
-
-  const [docLinks, blogLinks, pageLinks] = [
-    allDocs.data.docsConnection.edges,
-    allBlogs.data.blogsConnection.edges,
-    allPages.data.pagesConnection.edges,
-  ].map((collection) => {
-    const filteredCollection = filterEdgesByTenant(collection, product);
-    return getSlugsFromCollections(filteredCollection);
-  });
-
-  const privacyPage = (await tenantHasPrivacyPolicy(product))
-    ? [`privacy`]
-    : [];
-
-  return [
-    ...docLinks.map((doc) => `docs/${doc}`),
-    ...blogLinks.map((blog) => `blog/${blog}`),
-    ...pageLinks.filter((page) => page !== "home").map((page) => `${page}`),
-    ...privacyPage,
-  ];
-};
-
-const getDomainForTenant = (product: string) => {
-  if (!process.env.NEXT_PUBLIC_PRODUCT_LIST)
-    throw new Error("NEXT_PUBLIC_PRODUCT_LIST is not defined");
-  const productList: Product[] = JSON.parse(
-    process.env.NEXT_PUBLIC_PRODUCT_LIST
-  );
-
-  for (const item of productList) {
-    if (item.product === product) {
-      return item.domain;
-    }
-  }
-};
-
-type Edges = Edge[] | null | undefined;
-
-type Edge =
-  | {
-      node?: {
-        _sys: Partial<SystemInfo>;
-      } | null;
-    }
-  | null
-  | undefined;
-function mapConnection<T extends Edges, R>(
-  edges: T,
-  mapFn: (acc: R[], curr: Edge) => R[]
-): R[] {
-  if (!edges) return [];
-  return edges.reduce<R[]>((acc: R[], curr: Edge) => {
-    return mapFn(acc, curr);
-  }, []);
 }

--- a/components/shared/FooterServer.tsx
+++ b/components/shared/FooterServer.tsx
@@ -1,3 +1,4 @@
+import { tenantHasPrivacyPolicy } from "@utils/privacy";
 import client from "../../tina/__generated__/client";
 import FooterContent from "./FooterContent";
 
@@ -5,20 +6,9 @@ interface FooterServerProps {
   product: string;
 }
 
-const getHasPrivacyPolicy = async (product: string) => {
-  try {
-    const res = await client.queries.privacy({
-      relativePath: `${product}/index.mdx`,
-    });
-    return Boolean(res);
-  } catch {
-    return false;
-  }
-};
-
 export default async function FooterServer({ product }: FooterServerProps) {
   let footerData = null;
-  const hasPrivacyPolicy = await getHasPrivacyPolicy(product);
+  const hasPrivacyPolicy = await tenantHasPrivacyPolicy(product);
 
   try {
     const { data } = await client.queries.footer({

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,20 +1,24 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from "next/server";
 
 export function middleware(request: NextRequest) {
-  const hostname = request.headers.get('host');
+  console.log("middleware running...");
+  const hostname = request.headers.get("host");
   const { pathname } = request.nextUrl;
 
-  const isLocal = hostname?.includes('localhost') || hostname?.includes('127.0.0.1');
-  const isStaging = hostname?.includes('vercel.app');
-  const productList = process.env.NEXT_PUBLIC_PRODUCT_LIST ? JSON.parse(process.env.NEXT_PUBLIC_PRODUCT_LIST) : [];
+  const isLocal =
+    hostname?.includes("localhost") || hostname?.includes("127.0.0.1");
+  const isStaging = hostname?.includes("vercel.app");
+  const productList = process.env.NEXT_PUBLIC_PRODUCT_LIST
+    ? JSON.parse(process.env.NEXT_PUBLIC_PRODUCT_LIST)
+    : [];
 
   // Allow .well-known paths without rewriting
-  if (pathname.startsWith('/.well-known')) {
+  if (pathname.startsWith("/.well-known")) {
     return NextResponse.next(); // Bypass rewriting for these paths
   }
 
   // Allow TinaCMS admin paths
-  if (pathname.startsWith('/admin')) {
+  if (pathname.startsWith("/admin")) {
     return NextResponse.next();
   }
 
@@ -25,15 +29,26 @@ export function middleware(request: NextRequest) {
   }
 }
 
-function handleLocalRequest(pathname: string, productList: any[], request: NextRequest) {
-  const pathSegments = pathname.split('/').filter(segment => segment.length > 0);
-  const isProduct = productList.some(product => product.product === pathSegments[0]);
+function handleLocalRequest(
+  pathname: string,
+  productList: any[],
+  request: NextRequest
+) {
+  const pathSegments = pathname
+    .split("/")
+    .filter((segment) => segment.length > 0);
+  const isProduct = productList.some(
+    (product) => product.product === pathSegments[0]
+  );
 
   if (isProduct) {
-    const rewriteUrl = new URL(`/${pathSegments.join('/')}`, request.url);
+    const rewriteUrl = new URL(`/${pathSegments.join("/")}`, request.url);
     return NextResponse.rewrite(rewriteUrl);
   } else {
-    const rewriteUrl = new URL(`/${process.env.DEFAULT_PRODUCT}${pathname}`, request.url);
+    const rewriteUrl = new URL(
+      `/${process.env.DEFAULT_PRODUCT}${pathname}`,
+      request.url
+    );
     return NextResponse.rewrite(rewriteUrl);
   }
 }
@@ -54,7 +69,5 @@ function handleProductionRequest(
 }
 
 export const config = {
-  matcher: [
-    '/((?!api|_next|static|favicon.ico|.*\\..*).*)',
-  ],
+  matcher: ["/((?!api|_next|static|favicon.ico|.*\\..*).*)", "/sitemap.xml"],
 };

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "remark-parse": "^11.0.0",
     "remark-stringify": "^11.0.0",
     "sass": "^1.88.0",
+    "sitemap": "^8.0.0",
+    "stream": "^0.0.3",
     "strip-markdown": "^6.0.0",
     "tailwind-merge": "^3.0.2",
     "tailwindcss-animate": "^1.0.7",

--- a/src/types/product-list.ts
+++ b/src/types/product-list.ts
@@ -1,0 +1,4 @@
+export type Product = {
+  product: string;
+  domain: string;
+};

--- a/src/types/tina.ts
+++ b/src/types/tina.ts
@@ -1,6 +1,18 @@
-export type RemoveTinaMetadata<T> = Omit<
-  T,
-  "__typename" | "_values" | "_sys"
-> & {
+import { SystemInfo } from "@tina/__generated__/types";
+
+type RemoveTinaMetadata<T> = Omit<T, "__typename" | "_values" | "_sys"> & {
   __typename: string;
 };
+
+type Edges = Edge[] | null | undefined;
+
+type Edge =
+  | {
+      node?: {
+        _sys: Partial<SystemInfo>;
+      } | null;
+    }
+  | null
+  | undefined;
+
+export type { Edge, Edges, RemoveTinaMetadata };

--- a/utils/privacy.ts
+++ b/utils/privacy.ts
@@ -1,0 +1,12 @@
+import client from "@tina/__generated__/client";
+
+export const tenantHasPrivacyPolicy = async (product: string) => {
+  try {
+    const res = await client.queries.privacy({
+      relativePath: `${product}/index.mdx`,
+    });
+    return Boolean(res);
+  } catch {
+    return false;
+  }
+};

--- a/utils/sitemap.ts
+++ b/utils/sitemap.ts
@@ -41,6 +41,8 @@ const getAllUrls = async (product: string) => {
     ...blogLinks.map((blog) => `blog/${blog}`),
     ...pageLinks.map((page) => (page === "home" ? "" : page)),
     ...privacyPage,
+    "blog",
+    "docs",
   ];
 };
 

--- a/utils/sitemap.ts
+++ b/utils/sitemap.ts
@@ -1,0 +1,47 @@
+import client from "@tina/__generated__/client";
+import { SitemapStream, streamToPromise } from "sitemap";
+import { Readable } from "stream";
+import { tenantHasPrivacyPolicy } from "./privacy";
+import { filterEdgesByTenant, getSlugsFromCollections } from "./tina";
+
+const buildSitemap = async (hostname: string, paths: string[]) => {
+  const links = paths.map((path) => ({
+    url: path,
+    changefreq: "daily",
+    priority: 0.7,
+  }));
+
+  const stream = new SitemapStream({ hostname });
+  const sitemap = await streamToPromise(Readable.from(links).pipe(stream));
+  return sitemap.toString();
+};
+
+const getAllUrls = async (product: string) => {
+  const [allDocs, allPages, allBlogs] = await Promise.all([
+    client.queries.docsConnection(),
+    client.queries.pagesConnection(),
+    client.queries.blogsConnection(),
+  ]);
+
+  const [docLinks, blogLinks, pageLinks] = [
+    allDocs.data.docsConnection.edges,
+    allBlogs.data.blogsConnection.edges,
+    allPages.data.pagesConnection.edges,
+  ].map((collection) => {
+    const filteredCollection = filterEdgesByTenant(collection, product);
+    return getSlugsFromCollections(filteredCollection);
+  });
+
+  const privacyPage = (await tenantHasPrivacyPolicy(product))
+    ? [`privacy`]
+    : [];
+
+  return [
+    ...docLinks.map((doc) => `docs/${doc}`),
+    ...blogLinks.map((blog) => `blog/${blog}`),
+    ...pageLinks.filter((page) => page !== "home").map((page) => `${page}`),
+    ...privacyPage,
+  ];
+};
+
+export { buildSitemap, getAllUrls };

--- a/utils/sitemap.ts
+++ b/utils/sitemap.ts
@@ -39,7 +39,7 @@ const getAllUrls = async (product: string) => {
   return [
     ...docLinks.map((doc) => `docs/${doc}`),
     ...blogLinks.map((blog) => `blog/${blog}`),
-    ...pageLinks.filter((page) => page !== "home").map((page) => `${page}`),
+    ...pageLinks.map((page) => (page === "home" ? "" : page)),
     ...privacyPage,
   ];
 };

--- a/utils/tenancy.ts
+++ b/utils/tenancy.ts
@@ -1,0 +1,15 @@
+import { Product } from "@/types/product-list";
+
+export const getDomainForTenant = (product: string) => {
+  if (!process.env.NEXT_PUBLIC_PRODUCT_LIST)
+    throw new Error("NEXT_PUBLIC_PRODUCT_LIST is not defined");
+  const productList: Product[] = JSON.parse(
+    process.env.NEXT_PUBLIC_PRODUCT_LIST
+  );
+
+  for (const item of productList) {
+    if (item.product === product) {
+      return item.domain;
+    }
+  }
+};

--- a/utils/tina.ts
+++ b/utils/tina.ts
@@ -1,5 +1,15 @@
 import { Edge, Edges } from "@/types/tina";
 
+const mapConnection = <T extends Edges, R>(
+  edges: T,
+  mapFn: (acc: R[], curr: Edge) => R[]
+): R[] => {
+  if (!edges) return [];
+  return edges.reduce<R[]>((acc: R[], curr: Edge) => {
+    return mapFn(acc, curr);
+  }, []);
+};
+
 const filterEdgesByTenant = <T extends Edges>(
   connection: T,
   product: string
@@ -17,16 +27,6 @@ const getSlugsFromCollections = <T extends Edges>(edges: T): string[] => {
     const slug = curr?.node?._sys.breadcrumbs?.at(-1);
     if (!slug) return acc;
     return [...acc, slug];
-  }, []);
-};
-
-const mapConnection = <T extends Edges, R>(
-  edges: T,
-  mapFn: (acc: R[], curr: Edge) => R[]
-): R[] => {
-  if (!edges) return [];
-  return edges.reduce<R[]>((acc: R[], curr: Edge) => {
-    return mapFn(acc, curr);
   }, []);
 };
 

--- a/utils/tina.ts
+++ b/utils/tina.ts
@@ -1,0 +1,33 @@
+import { Edge, Edges } from "@/types/tina";
+
+const filterEdgesByTenant = <T extends Edges>(
+  connection: T,
+  product: string
+) => {
+  return mapConnection(connection, (acc: Edge[], curr) => {
+    const breadcrumb = curr?.node?._sys.breadcrumbs?.at(0);
+    if (!breadcrumb || breadcrumb !== product) return acc;
+    return [...acc, curr];
+  });
+};
+
+const getSlugsFromCollections = <T extends Edges>(edges: T): string[] => {
+  if (!edges) return [];
+  return edges.reduce<string[]>((acc, curr) => {
+    const slug = curr?.node?._sys.breadcrumbs?.at(-1);
+    if (!slug) return acc;
+    return [...acc, slug];
+  }, []);
+};
+
+const mapConnection = <T extends Edges, R>(
+  edges: T,
+  mapFn: (acc: R[], curr: Edge) => R[]
+): R[] => {
+  if (!edges) return [];
+  return edges.reduce<R[]>((acc: R[], curr: Edge) => {
+    return mapFn(acc, curr);
+  }, []);
+};
+
+export { filterEdgesByTenant, getSlugsFromCollections };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2440,6 +2440,18 @@
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-2.1.0.tgz#052aa67a48eccc4309d7f0191b7e41434b90bb78"
   integrity sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==
 
+"@types/node@*":
+  version "22.15.29"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.15.29.tgz#c75999124a8224a3f79dd8b6ccfb37d74098f678"
+  integrity sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==
+  dependencies:
+    undici-types "~6.21.0"
+
+"@types/node@^17.0.5":
+  version "17.0.45"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.45.tgz#2c0fafd78705e7a18b7906b5201a522719dc5190"
+  integrity sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==
+
 "@types/node@^22.15.17":
   version "22.15.17"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.15.17.tgz#355ccec95f705b664e4332bb64a7f07db30b7055"
@@ -2491,6 +2503,13 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
+
+"@types/sax@^1.2.1":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@types/sax/-/sax-1.2.7.tgz#ba5fe7df9aa9c89b6dff7688a19023dd2963091d"
+  integrity sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==
+  dependencies:
+    "@types/node" "*"
 
 "@types/tern@*":
   version "0.23.9"
@@ -3277,7 +3296,7 @@ anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-arg@^5.0.2:
+arg@^5.0.0, arg@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/arg/-/arg-5.0.2.tgz#c81433cc427c92c4dcf4865142dbca6f15acd59c"
   integrity sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==
@@ -3920,6 +3939,11 @@ common-tags@1.8.2:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.2.tgz#94ebb3c076d26032745fd54face7f688ef5ac9c6"
   integrity sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==
+
+component-emitter@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-2.0.0.tgz#3a137dfe66fcf2efe3eab7cb7d5f51741b3620c6"
+  integrity sha512-4m5s3Me2xxlVKG9PkZpQqHQR7bgpnN7joDMJ4yvVkVXngjoITG76IaZmzmywSeRTeTpc6N6r3H3+KyUurV8OYw==
 
 compute-scroll-into-view@^1.0.17:
   version "1.0.20"
@@ -9301,6 +9325,11 @@ sass@^1.88.0:
   optionalDependencies:
     "@parcel/watcher" "^2.4.1"
 
+sax@^1.2.4:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.4.1.tgz#44cc8988377f126304d3b3fc1010c733b929ef0f"
+  integrity sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==
+
 scheduler@^0.23.2:
   version "0.23.2"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.2.tgz#414ba64a3b282892e944cf2108ecc078d115cdc3"
@@ -9572,6 +9601,16 @@ sisteransi@^1.0.5:
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
 
+sitemap@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/sitemap/-/sitemap-8.0.0.tgz#eb6ea48f95787cd680b83683c555d6f6b5a903fd"
+  integrity sha512-+AbdxhM9kJsHtruUF39bwS/B0Fytw6Fr1o4ZAIAEqA6cke2xcoO2GleBw9Zw7nRzILVEgz7zBM5GiTJjie1G9A==
+  dependencies:
+    "@types/node" "^17.0.5"
+    "@types/sax" "^1.2.1"
+    arg "^5.0.0"
+    sax "^1.2.4"
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
@@ -9712,6 +9751,13 @@ stopword@^3.1.4:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/stopword/-/stopword-3.1.4.tgz#b490032ac76daee68feccd8b6ec9e4a8da5ab117"
   integrity sha512-RiyU12FwHWX1i42gxhn5sywgpV5mptZTzbHKqKh5wVDWC2Uu+8vKbLv8xxeNa0p29vECbYGLXpDayo54n9+dsg==
+
+stream@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/stream/-/stream-0.0.3.tgz#3f3934a900a561ce3e2b9ffbd2819cead32699d9"
+  integrity sha512-aMsbn7VKrl4A2T7QAQQbzgN7NVc70vgF5INQrBXqn4dCXN1zy3L9HGgLO5s7PExmdrzTJ8uR/27aviW8or8/+A==
+  dependencies:
+    component-emitter "^2.0.0"
 
 streamroller@^3.1.5:
   version "3.1.5"


### PR DESCRIPTION
### Description

**Note**: As we need to serve a different sitemap depending on the tenant the user is accessing, I was not able to use the [typical approach in Next.js](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap) for generating a sitemap. I've instead created a route that will serve the appropriate sitemap.

### Related Issue
https://github.com/SSWConsulting/SSW.YakShaver/issues/1145

### Screenshot

![image](https://github.com/user-attachments/assets/1398c2c8-13c8-4a1c-9510-e1818677a8b2)
**Figure: Sitemap for Yakshaver.ai**


