### PR TITLE
fix cropping of typewriter highlighted words & cleaned up html

### DIFF
--- a/components/utilityComponents/TypewriterAnimation.tsx
+++ b/components/utilityComponents/TypewriterAnimation.tsx
@@ -121,30 +121,13 @@ const TypewriterAnimation = React.forwardRef<
       {parts.map((part, index) =>
         part.highlight ? (
           <span
-            key={index}
-            className={`
-              relative overflow-hidden
-              ${
-                isHighlightingComplete
-                  ? "text-black bg-white rounded-[2px]"
-                  : "text-white bg-none"
-              }
-              transition-colors duration-500 ease-in-out
-            `}
+            key={`hightlight-${index}`}
+            className={cn(
+              "px-[0.1rem] transition-colors duration-500 ease-in-out rounded-[2px]",
+              isHighlightingComplete && "text-black bg-white "
+            )}
           >
-            {/* Background highlight with animation */}
-            <span
-              className={`
-                absolute inset-0
-                bg-white
-                rounded-[2px]
-                origin-left
-                ${isHighlightingComplete ? "scale-x-100" : "scale-x-0"}
-                transition-transform duration-500 ease-in-out
-                -z-10
-              `}
-            />
-            <span className={"px-[0.1rem]"}>{part.text}</span>
+            {part.text}
           </span>
         ) : (
           part.text


### PR DESCRIPTION
### Description
I noticed the highlight box for the typewriter animation gets sheared off on the left hand side so I fixed it. There were also several span tags not doing anything that I removed to make the code cleaner.

### Screenshots

![image](https://github.com/user-attachments/assets/55be2520-41c8-4805-9ce3-d56ca722bfd5)
**❌Figure: Before**

![image](https://github.com/user-attachments/assets/b17fc374-394b-4050-bdc8-ea3e794590bf)
**✅Figure: After**