### PR TITLE
💄 Reduce EagleEye Docs nav width

### DIFF
--- a/app/[product]/docs/layout.tsx
+++ b/app/[product]/docs/layout.tsx
@@ -16,7 +16,7 @@ const RootLayout = async ({
   return (
     <>
       <SearchBox.Root index={tableOfContentsData.algoliaSearchIndex!}>
-        <div className="grid grid-cols-1 h-full  md:grid-cols-[1.25fr_3fr] lg:grid-cols-[1fr_3fr] max-w-360 mx-auto">
+        <div className="grid grid-cols-1 h-full  md:grid-cols-[1fr_3fr] lg:grid-cols-[0.8fr_3fr] max-w-360 mx-auto">
           {/* LEFT COLUMN 1/3 */}
           <div className=" max-h-[calc(100vh-13rem)] mt-20 hidden md:block py-8 bg-gray-darkest max-w-[calc(100%_-_2rem)]   mb-8 rounded-lg left-4 top-44 text-white self-start px-6  overflow-y-auto [scrollbar-width:thin] [scrollbar-color:var(--color-ssw-charcoal)_transparent] sticky">
             <TableOfContentsClient


### PR DESCRIPTION
From: @adamcogan  
Sent: Wednesday, 16 July 2025 3:53 AM
To: @tiagov8 
Cc: @jeoffreyfischer 
Subject: EagleEye docs - reduce left nav width

**Change**
The left nav width has been reduced

**Screenshot**
<img width="3840" height="2182" alt="image" src="https://github.com/user-attachments/assets/e9e168c0-a885-4cf0-80b4-cc0204a565ea" />
**Figure: Side menu width is reduced**