### PR TITLE
Update DocAndBlogMarkdownStyle.tsx to add margin to videos

### DIFF
--- a/tina/tinamarkdownStyles/DocAndBlogMarkdownStyle.tsx
+++ b/tina/tinamarkdownStyles/DocAndBlogMarkdownStyle.tsx
@@ -12,7 +12,7 @@ export const DocAndBlogMarkdownStyle: Components<{
       sizeClass = "w-full h-auto max-w-[800px]";
     }
     return (
-      <div className="youtube-container">
+      <div className="youtube-container mb-2">
         <YouTubeEmbed
           className={sizeClass}
           src={props.externalVideoLink}


### PR DESCRIPTION
cc @Aibono1225 @AttackOnMorty 

Added margin bottom to video as per @adamcogan 's  **Re: EagleEye YouTube - click ◼️black play, then click 🟥 red play**

E.g.: https://ssweagleeye.com/docs/report-description

<img width="686" height="331" alt="Screenshot 2025-08-13 at 11 36 49 AM" src="https://github.com/user-attachments/assets/0ca3a57e-2064-4498-8b69-5405f18482b1" />

