### PR TITLE
Update YouTubeEmbed.tsx to make play button red

### DIFF
--- a/components/shared/YouTubeEmbed.tsx
+++ b/components/shared/YouTubeEmbed.tsx
@@ -20,8 +20,8 @@ export const YouTubeEmbed = ({
   return (
     <div className={cn("relative aspect-video w-full", className)}>
       {!clicked ? (
-        <div className="bg-black group aspect-video  relative rounded-lg **:duration-200">
-          <div className="p-5 inline-flex group-hover:scale-115 items-center justify-center absolute  rounded-full top-1/2 left-1/2 border-gradient-pink -translate-x-1/2 border-gradient-foreground-gray-darkest -translate-y-1/2 z-20">
+        <div className="bg-black group aspect-video relative rounded-lg **:duration-200">
+          <div className="p-5 inline-flex group-hover:scale-115 items-center justify-center absolute rounded-full top-1/2 left-1/2 -translate-x-1/2 bg-ssw-red -translate-y-1/2 z-20">
             <FaPlay
               className="text-white pl-1 transition-transform ease-out md:text-7xl text-5xl cursor-pointer"
               onClick={() => setClicked(true)}


### PR DESCRIPTION
as per @adamcogan 's **Re: EagleEye YouTube - click ◼️black play, then click 🟥 red play**

from

<img width="847" height="473" alt="Screenshot 2025-08-13 at 2 55 17 PM" src="https://github.com/user-attachments/assets/b058c909-b58b-4d83-94df-5f06ae4e2cc3" />


to

<img width="854" height="481" alt="Screenshot 2025-08-13 at 2 55 12 PM" src="https://github.com/user-attachments/assets/9243720f-949f-4bd9-95f6-0f869eb7428b" />
