### PR TITLE
Fix max-height limit on nav items 

### DIFF
--- a/app/[product]/docs/[slug]/TableOfContentsClient.tsx
+++ b/app/[product]/docs/[slug]/TableOfContentsClient.tsx
@@ -43,7 +43,7 @@ function NavigationGroup({ navigationGroup, activeItem }: {
 
         <div
           className={`overflow-hidden transition-all duration-300 ease-in-out ${
-            isExpanded ? "max-h-96 opacity-100" : "max-h-0 opacity-0"
+            isExpanded ? "opacity-100" : "max-h-0 opacity-0"
           }`}
         >
           <ul className="pt-1">

--- a/app/[product]/docs/[slug]/page.tsx
+++ b/app/[product]/docs/[slug]/page.tsx
@@ -76,7 +76,7 @@ export default async function DocPost({ params, locale }: DocPostProps) {
         query={documentData.query}
         variables={documentData.variables}
         pageData={{ docs: documentData.docs }}
-        tableOfContentsData={tableOfContentsData as any}
+        tableOfContentsData={tableOfContentsData as DocsTableOfContents}
       />
       <PaginationLinksClient
         prev={paginationData.prev}


### PR DESCRIPTION
As per https://github.com/SSWConsulting/SSW.YakShaver/issues/2907 

<img width="340" height="432" alt="Screenshot 2025-09-19 at 10 16 44 am" src="https://github.com/user-attachments/assets/2d6fc3be-ce4b-4f67-8192-936bb204bf44" />

**Figure: ❌ Before - max-h restricts nav items**

<img width="351" height="822" alt="Screenshot 2025-09-19 at 10 14 55 am" src="https://github.com/user-attachments/assets/e7d23004-649f-4ffe-8932-850ff41b7cca" />

**Figure: ✅ After - max-h removed**