### PR TITLE
Added login button to navbar to make visible for user

### DIFF
--- a/components/shared/NavBarClient.tsx
+++ b/components/shared/NavBarClient.tsx
@@ -196,9 +196,7 @@ const ButtonMap = ({ item, className, contextualHref }: {
             className
           )}
           href={item.href}
-          variant={
-            (item?.variant ? "white" : item.variant) as "outline" | "white"
-          }
+          variant={(item?.variant ?? "white") as "outline" | "white"}
           key={item.label}
         >
           <Link href={contextualHref(item.href || "")}>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -13,8 +13,7 @@ const buttonVariants = cva(
         white: "bg-white text-black hover:bg-white/80",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-        outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        outline: "border-1 border-white hover:bg-white/20 text-white",
         secondary: "bg-ssw-charcoal text-white hover:text-black hover:bg-white",
         ghost: "hover:text-ssw-red",
         link: "text-primary underline-offset-4 hover:underline",

--- a/content/navBars/YakShaver/YakShaver-NavigationBar.json
+++ b/content/navBars/YakShaver/YakShaver-NavigationBar.json
@@ -58,10 +58,14 @@
   ],
   "buttons": [
     {
-      "label": "Sign Up for Free",
+      "label": "Log in",
       "href": "https://portal.yakshaver.ai/",
-      "icon": "/YakShaver/yakshaver-black.svg",
-      "iconPosition": "left",
+      "variant": "outline",
+      "_template": "buttonLink"
+    },
+    {
+      "label": "Sign up",
+      "href": "https://portal.yakshaver.ai/",
       "variant": "white",
       "_template": "buttonLink"
     }

--- a/content/navBars/YakShaver/YakShaver-NavigationBar.json
+++ b/content/navBars/YakShaver/YakShaver-NavigationBar.json
@@ -66,6 +66,8 @@
     {
       "label": "Sign up",
       "href": "https://portal.yakshaver.ai/",
+      "icon": "/YakShaver/yakshaver-black.svg",
+      "iconPosition": "left",
       "variant": "white",
       "_template": "buttonLink"
     }


### PR DESCRIPTION
Currently the home page has only one button on navbar "Sign up for free" which confuses users about how to navigate to portal, or how to login to the system.

I've talked with @micsblank , and agreed to add "Log in" button which is more visible and indicates user to log into the system. We don't need to use extra "Portal" word on button because it is descriptive to us.

<img width="1893" height="962" alt="image" src="https://github.com/user-attachments/assets/532c3cf9-7ff8-40b9-9690-22f46516077d" />

**Figure: Current navbar**

<img width="1882" height="902" alt="image" src="https://github.com/user-attachments/assets/0e0cec08-acf1-4240-9ff5-91d807eea013" />

**Figure: New navbar**
