### PR TITLE
Fixed block quote rendering

### DIFF
--- a/tina/tinamarkdownStyles/DocAndBlogMarkdownStyle.tsx
+++ b/tina/tinamarkdownStyles/DocAndBlogMarkdownStyle.tsx
@@ -43,8 +43,9 @@ export const DocAndBlogMarkdownStyle: Components<{
   h4: (props) => (
     <h4 className="text-lg font-semibold mb-3 mt-6">{props?.children}</h4>
   ),
-
-  block_quote: (props) => (
+  // @ts-ignore - TODO: remove tsignore after typescript definitions for blockquotes are fixed 
+  // https://github.com/tinacms/tinacms/pull/6083
+  blockquote: (props) => (
     <blockquote className="p-4 my-4 border-s-4 border-white/20">{props?.children}</blockquote>
   ),
 


### PR DESCRIPTION
CC: @tiagov8 

I'd test this out by going to `/docs/yakshaver-tips`

That's the only page I know of that uses block quotes 

### Description
@tiagov8 made some updates to how block quotes render on the site, but used the wrong key inside inside the `TinaMarkdown` components dictionary. The typescript definitions for the correct key is wrong, so I also added a **TODO** for fixing this properly after my PR for Tina is merged.

### Screenshot
<img width="1592" height="772" alt="image" src="https://github.com/user-attachments/assets/b53c58ca-cca8-47fd-ae86-283c4c7d7da6" />

**Figure: Fixed block quote rendering**