### PR TITLE
fix(nav): default mobile menu to closed on initial render

### DIFF
--- a/components/NavBar/MobileMenu.tsx
+++ b/components/NavBar/MobileMenu.tsx
@@ -53,7 +53,7 @@ function HeaderHeightProvider({
 const MobileAnchor = Popover.Anchor;
 
 const MobileMenuRoot = ({ children }: { children: React.ReactNode }) => {
-  const [isOpen, setIsOpen] = useState(true);
+  const [isOpen, setIsOpen] = useState(false);
   const isMobile = useMatchMedia("(max-width: 1279px)");
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Fix mobile menu rendering open on page load due to `useState(true)` left from debugging in #678
- Changed `MobileMenuRoot` initial state back to `useState(false)`

## Test plan
- [ ] Verify mobile menu is closed on initial page load
- [ ] Verify menu opens/closes correctly when toggling the hamburger button
- [ ] Verify body scroll lock still works when menu is open on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)