### PR TITLE
🐛 Fix: Mobile header buttons overlap logo and language icon disappears

### DIFF
--- a/components/NavBar/NavigationMenu.tsx
+++ b/components/NavBar/NavigationMenu.tsx
@@ -20,7 +20,7 @@ const NavigationMenuBadge = ({
   imgHeight,
   currentLocale = "en",
 }: NavigationMenuBadgeProps) => (
-  <NavigationMenu.Item className="gap-8 mx-auto flex items-center w-full">
+  <NavigationMenu.Item className="gap-8 flex items-center w-full sm:w-auto shrink-0">
     <Link className="mb-2 shrink-0" href={getLocalizedPath("/", currentLocale)}>
       <Image
         src={imgSrc}

--- a/components/shared/NavBarClient.tsx
+++ b/components/shared/NavBarClient.tsx
@@ -187,10 +187,13 @@ function NavBarClientContent({
             </NavigationMenuItem>
           );
         })}
-        <NavigationMenuItem className="hidden sm:block pl-5 flex items-center">
+        <NavigationMenuItem className="hidden sm:flex pl-5 items-center">
           <LanguageToggle currentLocale={currentLocale} />
         </NavigationMenuItem>
-        <NavigationMenuItem className="flex xl:hidden justify-end pl-5">
+        <NavigationMenuItem className="flex xl:hidden justify-end pl-5 items-center gap-3">
+          <span className="sm:hidden">
+            <LanguageToggle currentLocale={currentLocale} />
+          </span>
           <MobileMenuTrigger />
           <MobileMenuContent headerHeight={headerHeight}>
             <>


### PR DESCRIPTION
Closes #681

## Changes
- **Fix logo overlap**: Changed `NavigationMenuBadge` item className from `w-full mx-auto` to `w-full sm:w-auto shrink-0` so the logo doesn't force 100% width in the flex container at sm+ breakpoints, preventing buttons from overlapping the logo.
- **Show language toggle on mobile**: Added a `LanguageToggle` next to the mobile hamburger menu trigger (wrapped in `sm:hidden`) so it remains visible below the sm breakpoint. The desktop language toggle (`hidden sm:flex`) still handles sm+ viewports.
- **Fix conflicting Tailwind classes**: Changed the desktop language toggle container from `hidden sm:block flex` to `hidden sm:flex` to resolve conflicting display utility classes.

## Testing
1. Open a product website (e.g. YakShaver) in browser dev tools
2. Reduce viewport width from desktop through mobile sizes
3. Verify:
   - Header buttons do not overlap the log
## Changes
- **Fix logo overlap**: Changed `NavigationMenuBadge` item className from `w-full mx-auto` to `w-full sm:w-he - **Fix re - **Show language toggle on mobile**: Added a `LanguageToggle` next to the mo echo 
 