### PR TITLE
Fix mobile header buttons overlapping logo and restore language toggle

### DIFF
--- a/components/NavBar/NavigationMenu.tsx
+++ b/components/NavBar/NavigationMenu.tsx
@@ -20,7 +20,7 @@ const NavigationMenuBadge = ({
   imgHeight,
   currentLocale = "en",
 }: NavigationMenuBadgeProps) => (
-  <NavigationMenu.Item className="gap-8 mx-auto flex items-center w-full">
+  <NavigationMenu.Item className="gap-8 flex items-center w-full md:flex-1 md:w-auto">
     <Link className="mb-2 shrink-0" href={getLocalizedPath("/", currentLocale)}>
       <Image
         src={imgSrc}
@@ -56,7 +56,7 @@ const NavigationMenuRoot = React.forwardRef<
       )}
       ref={ref}
     >
-      <NavigationMenu.List className="sm:flex gap-x-5 sm:gap-y-0 gap-y-4 sm:gap-x-0 grid-cols-2 grid mx-4 xl:mx-auto max-w-7xl m-0 justify-center">
+      <NavigationMenu.List className="md:flex gap-x-5 md:gap-y-0 gap-y-4 md:gap-x-0 grid-cols-2 grid mx-4 xl:mx-auto max-w-7xl m-0 justify-center md:justify-start">
         {children}
       </NavigationMenu.List>
     </NavigationMenu.Root>

--- a/components/shared/Blocks/BookingButton.tsx
+++ b/components/shared/Blocks/BookingButton.tsx
@@ -34,7 +34,7 @@ export const BookingButton = ({
         className={cn(
           variantMap[variant],
           className,
-          `px-5 py-2 min-h-[42px] font-semibold text-center transition-all items-center text-white rounded-lg whitespace-nowrap uppercase flex`
+          `px-5 py-2 min-h-[42px] font-semibold text-center transition-all items-center justify-center text-white rounded-lg whitespace-nowrap uppercase flex`
         )}
       >
         {title}

--- a/components/shared/NavBarClient.tsx
+++ b/components/shared/NavBarClient.tsx
@@ -178,8 +178,8 @@ function NavBarClientContent({
         {buttons.map((button, index) => {
           return (
             <NavigationMenuItem
-              className={`hidden sm:block ${
-                index === buttons.length - 1 ? "pl-5" : "pl-12"
+              className={`hidden md:block ${
+                index === buttons.length - 1 ? "pl-5" : "pl-5 xl:pl-12"
               }`}
               key={index}
             >
@@ -187,7 +187,7 @@ function NavBarClientContent({
             </NavigationMenuItem>
           );
         })}
-        <NavigationMenuItem className="hidden sm:block pl-5 flex items-center">
+        <NavigationMenuItem className="hidden md:flex pl-5 items-center">
           <LanguageToggle currentLocale={currentLocale} />
         </NavigationMenuItem>
         <NavigationMenuItem className="flex xl:hidden justify-end pl-5">
@@ -228,6 +228,9 @@ function NavBarClientContent({
                   );
                 }
               })}
+              <li className="flex items-center py-1 mb-0 mt-4">
+                <LanguageToggle currentLocale={currentLocale} />
+              </li>
             </>
           </MobileMenuContent>
         </NavigationMenuItem>
@@ -235,10 +238,10 @@ function NavBarClientContent({
           return (
             <NavigationMenuItem
               className={clsx(
-                "w-full col-span-1 block sm:hidden",
+                "w-full block md:hidden",
                 index === buttons.length - 1 && index % 2 === 0
                   ? "col-span-2"
-                  : "col-span-1"
+                  : "col-span-2 min-[390px]:col-span-1"
               )}
               key={index}
             >


### PR DESCRIPTION
## Summary
- Raised the grid-to-flex layout breakpoint from `sm` (640px) to `md` (768px) so header buttons drop to their own row before overlapping the logo
- Added language toggle inside the mobile hamburger menu so it remains accessible at all viewport widths
- Centered the "Contact Us" button label and switched to single-column buttons under 390px

Closes #681

## Test plan
- [x] At **1280px+**: full desktop nav with all items, buttons, and language icon visible inline
- [x] At **768–1280px**: logo left, buttons + language + hamburger right, no overlap
- [x] At **390–768px**: logo + hamburger row, two-column buttons row below
- [x] At **<390px**: single-column full-width buttons
- [x] Open hamburger menu on mobile — language toggle is visible
- [ ] Verify on both YakShaver and EagleEye

🤖 Generated with [Claude Code](https://claude.com/claude-code)