### PR TITLE
update(EagleEye): reframe pricing for free beta period

### DIFF
--- a/components/shared/Blocks/Pricing.tsx
+++ b/components/shared/Blocks/Pricing.tsx
@@ -89,7 +89,7 @@ const Pricing = ({ data }: PricingProps) => {
 
       {description && (
         <div
-          className="text-white text-base text-center px-4 mb-8 [&_a]:text-[#CC4141] [&_a]:underline [&_a]:underline-offset-4 hover:[&_a]:text-red-400"
+          className="text-white text-base text-center px-4 mb-8 [&_a]:text-[#CC4141] [&_a]:underline [&_a]:underline-offset-4 [&_a:hover]:text-red-400"
           data-tina-field={tinaField(data, "description")}
         >
           <TinaMarkdown content={description} />

--- a/components/shared/Blocks/Pricing.tsx
+++ b/components/shared/Blocks/Pricing.tsx
@@ -11,7 +11,6 @@ import { ShineBorder } from "@/components/magicui/shine-border";
 import { BsCheck } from "react-icons/bs";
 import { BookingButton } from "./BookingButton";
 import { ButtonVariant } from "./buttonEnum";
-import { cn } from "@/lib/utils";
 
 interface PlanAction {
   label: string;
@@ -67,7 +66,7 @@ const Pricing = ({ data }: PricingProps) => {
 
   const getGridClasses = (planCount: number) => {
     if (planCount === 1) {
-      return "grid grid-cols-1 gap-4 lg:gap-8 xl:grid-cols-3 lg:justify-items-center px-4 lg:px-12";
+      return "grid grid-cols-1 gap-4 lg:gap-8 max-w-xl mx-auto px-4 lg:px-12";
     } else if (planCount === 2) {
       return "grid grid-cols-1 gap-4 lg:gap-8 lg:grid-cols-2 px-4 lg:px-12";
     } else if (planCount === 3) {
@@ -90,7 +89,7 @@ const Pricing = ({ data }: PricingProps) => {
 
       {description && (
         <div
-          className="text-white text-base text-center px-4 mb-8"
+          className="text-white text-base text-center px-4 mb-8 [&_a]:text-[#CC4141] [&_a]:underline [&_a]:underline-offset-4 hover:[&_a]:text-red-400"
           data-tina-field={tinaField(data, "description")}
         >
           <TinaMarkdown content={description} />
@@ -102,10 +101,7 @@ const Pricing = ({ data }: PricingProps) => {
           plans.length > 0 &&
           plans.map((plan, index) => (
             <div
-              className={cn(
-                "flex flex-col h-full",
-                plans.length === 1 ? "first:xl:col-start-2" : ""
-              )}
+              className="flex flex-col h-full"
               key={index}
             >
               {plan.isRecommended ? (

--- a/content/pages/EagleEye/pricing.json
+++ b/content/pages/EagleEye/pricing.json
@@ -7,20 +7,23 @@
   "pageBlocks": [
     {
       "title": "{Simple, Transparent Pricing}",
-      "description": "🎉 **Great news!** EagleEye is currently **completely free** to use through the Azure Marketplace! 🚀\n",
+      "description": "🎉 EagleEye is **free during our public beta until 1 July 2027**. Final pricing will be announced before the beta ends — join the waitlist to be notified.\n",
       "plans": [
         {
-          "planTier": "Free",
-          "planDescription": "For small team",
+          "planTier": "Free Beta",
+          "planDescription": "Available now",
           "price": "$0",
-          "subPriceText": "1 - 5 units",
-          "priceDescription": "* Units are calculated based on the number of mailboxes",
+          "subPriceText": "All features included",
+          "priceDescription": "",
           "isRecommended": true,
-          "recommendation": "3 Months Free Trial",
+          "recommendation": "Available Now",
           "listTitle": "Get started with",
           "listItems": [
-            "Basic Tag features",
-            "Full webhook support"
+            "Unlimited mailboxes",
+            "Reports and analytics",
+            "Rule-based tags",
+            "AI tags",
+            "Workflows"
           ],
           "buttons": [
             {
@@ -34,17 +37,15 @@
         },
         {
           "planTier": "Pro",
-          "planDescription": "For large team",
-          "price": "$1 / unit / month",
-          "subPriceText": "5+ units",
-          "priceDescription": "* Units are calculated based on the number of mailboxes",
+          "planDescription": "Post-beta pricing",
+          "price": "Coming soon",
+          "subPriceText": "Final pricing to be announced",
+          "priceDescription": "",
           "isRecommended": false,
-          "listTitle": "Get started with",
+          "listTitle": "Everything in Free Beta, plus",
           "listItems": [
-            "{Everything in Free, plus}",
-            "Advanced AI-powerd Tag features",
-            "Unlimited team size",
-            "Unlimited mailboxes for email analysis"
+            "Continued access after the beta period",
+            "Priority support"
           ],
           "buttons": [
             {

--- a/content/pages/EagleEye/pricing.json
+++ b/content/pages/EagleEye/pricing.json
@@ -7,16 +7,16 @@
   "pageBlocks": [
     {
       "title": "{Simple, Transparent Pricing}",
-      "description": "🎉 EagleEye is **free during our public beta until 1 July 2027**. Final pricing will be announced before the beta ends — join the waitlist to be notified.\n",
+      "description": "🎉 EagleEye is **free during our public beta until 1 July 2027**. Final pricing will be announced before the beta ends — [join the waitlist](https://form.jotform.com/233468468973070) to be notified.\n",
       "plans": [
         {
-          "planTier": "Free Beta",
+          "planTier": "Free",
           "planDescription": "Available now",
           "price": "$0",
           "subPriceText": "All features included",
           "priceDescription": "",
           "isRecommended": true,
-          "recommendation": "Available Now",
+          "recommendation": "Public Beta",
           "listTitle": "Get started with",
           "listItems": [
             "Unlimited mailboxes",
@@ -32,26 +32,6 @@
               "size": "medium",
               "url": "https://ssweagleeye.com/docs/prerequisites",
               "_template": "actions"
-            }
-          ]
-        },
-        {
-          "planTier": "Pro",
-          "planDescription": "Post-beta pricing",
-          "price": "Coming soon",
-          "subPriceText": "Final pricing to be announced",
-          "priceDescription": "",
-          "isRecommended": false,
-          "listTitle": "Everything in Free Beta, plus",
-          "listItems": [
-            "Continued access after the beta period",
-            "Priority support"
-          ],
-          "buttons": [
-            {
-              "Title": "Join Waitlist",
-              "JotFormId": "233468468973070",
-              "_template": "BookingButton"
             }
           ]
         }


### PR DESCRIPTION

<img width="1800" height="1130" alt="Microsoft Teams (work or school) 2026-04-17 12 03 57" src="https://github.com/user-attachments/assets/4b6c8e68-b53a-49b1-8c5e-a718d1c7eee9" />


## Summary
- Replaces outdated Free/Pro tiering with **Free Beta** (current) and **Pro** (post-beta, waitlist)
- Feature lists now match the portal's Subscription page (Unlimited mailboxes, Reports and analytics, Rule-based tags, AI tags, Workflows)
- Beta end date (1 July 2027) stated once in the header; removed duplicate priceDescription copy on both cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)