### PR TITLE
Fix YakShaver navbar logo mismatch between local and production

### DIFF
--- a/components/shared/NavBarServer.tsx
+++ b/components/shared/NavBarServer.tsx
@@ -49,9 +49,28 @@ export default async function NavBarServer({ product, locale }: NavBarServerProp
     data.navigationBar.buttons?.filter((button) => button !== null) || [];
   const { imgSrc, imgHeight, imgWidth, showLanguageToggle } =
     data.navigationBar || {};
+
+  const normalizedImgSrc = (() => {
+    if (product !== "YakShaver" || typeof imgSrc !== "string") {
+      return imgSrc;
+    }
+    if (!imgSrc.includes("assets.tina.io")) {
+      return imgSrc;
+    }
+    try {
+      const url = new URL(imgSrc);
+      if (url.pathname.includes("yakshaver-logo.png")) {
+        return "/yakshaver-logo.png";
+      }
+    } catch {
+      // Ignore URL parsing errors
+    }
+    return imgSrc;
+  })();
+
   const bannerImage =
-    imgSrc && imgHeight && imgWidth
-      ? { imgHeight, imgSrc, imgWidth }
+    normalizedImgSrc && imgHeight && imgWidth
+      ? { imgHeight, imgSrc: normalizedImgSrc, imgWidth }
       : undefined;
   return (
     <NavBarClient


### PR DESCRIPTION
## Summary
- normalize YakShaver navbar logo source when Tina returns hosted assets URL
- force this specific case to use /yakshaver-logo.png so local and production match

## Why
Production was rendering a different binary logo from assets.tina.io while localhost used the repository logo file, causing a visible mismatch.

## Validation
- confirmed no errors in components/shared/NavBarServer.tsx
- verified local YakShaver navbar logo resolves to /yakshaver-logo.png