### PR TITLE
fix(i18n): make zh pages render Chinese content + add zh install page

### DIFF
--- a/app/[product]/[filename]/page.tsx
+++ b/app/[product]/[filename]/page.tsx
@@ -7,7 +7,6 @@ import NotFoundError from "@/errors/not-found";
 import ClientFallbackPage from "../../client-fallback-page";
 import { notFound } from "next/navigation";
 
-export const dynamic = 'force-static';
 interface FilePageProps {
   params: Promise<{ product: string; filename: string }>;
 }

--- a/content/navBars/YakShaver/zh/YakShaver-NavigationBar.json
+++ b/content/navBars/YakShaver/zh/YakShaver-NavigationBar.json
@@ -16,6 +16,12 @@
       "_template": "stringItem"
     },
     {
+      "label": "安装",
+      "href": "/install",
+      "title": "安装",
+      "_template": "stringItem"
+    },
+    {
       "label": "博客",
       "href": "/blog",
       "_template": "stringItem"
@@ -46,7 +52,8 @@
         },
         {
           "label": "Discord",
-          "href": "https://discord.gg/Jp9dyxKFjR"
+          "href": "https://discord.gg/Jp9dyxKFjR",
+          "openInNewTab": true
         }
       ],
       "_template": "groupOfStringItems"
@@ -54,25 +61,25 @@
     {
       "label": "视频",
       "href": "https://www.youtube.com/@SSWYakShaver",
+      "openInNewTab": true,
       "_template": "stringItem"
     }
   ],
   "buttons": [
     {
-      "label": "登录",
-      "variant": "outlinedWhite",
-      "_template": "actions",
-      "url": "https://portal.yakshaver.ai/",
-      "size": "medium"
+      "Title": "联系我们",
+      "JotFormId": "233468468973070",
+      "variants": "outline",
+      "_template": "BookingButton"
     },
     {
-      "label": "注册",
+      "label": "门户",
       "icon": "/YakShaver/yakshaver-black.svg",
       "iconPosition": "left",
       "variant": "solidWhite",
       "_template": "actions",
-      "url": "https://portal.yakshaver.ai/",
-      "size": "medium"
+      "size": "medium",
+      "url": "https://portal.yakshaver.ai/"
     }
   ]
 }

--- a/content/pages/YakShaver/zh/home.json
+++ b/content/pages/YakShaver/zh/home.json
@@ -10,12 +10,7 @@
       "backgroundImageEnabled": false,
       "titleBeforeRotate": "快速制作完美的",
       "titleAfterRotate": "仅需几秒",
-      "rotatingWords": [
-        "PBI",
-        "任务",
-        "工单",
-        "邮件"
-      ],
+      "rotatingWords": ["PBI", "任务", "工单", "邮件"],
       "byLine": "别再浪费时间写错误报告了。\n\nYakShaver AI 代理分析录音，生成任务，并立即分配给正确的团队。\n\n使用 YakShaver 节省数小时的挫败感。\n",
       "ctaRight": {
         "title": "观看视频",
@@ -187,14 +182,11 @@
     },
     {
       "title": "简单透明的定价",
-      "desc": "共享剃除额度。一次付费，组织内任何人都可以报告问题。零按席位收费——尽情剃除！",
+      "desc": "共享剃除额度。一次付费，组织内任何人都可以报告问题。不按人头收费——尽情剃除！",
       "tiers": [
         {
           "tier": "入门",
-          "description": [
-            "每月 15 次剃除",
-            "适合个人"
-          ],
+          "description": ["每月 15 次剃除", "适合个人"],
           "price": 0,
           "estimatedHoursSaved": 7.5,
           "itemsAbleToCreate": 15,
@@ -208,10 +200,7 @@
         },
         {
           "tier": "团队",
-          "description": [
-            "每月 100 次剃除",
-            "适合成长中的团队"
-          ],
+          "description": ["每月 100 次剃除", "适合成长中的团队"],
           "price": 39,
           "estimatedHoursSaved": 50,
           "itemsAbleToCreate": 100,
@@ -225,10 +214,7 @@
         },
         {
           "tier": "成长",
-          "description": [
-            "每月 500 次剃除",
-            "适合大型组织"
-          ],
+          "description": ["每月 500 次剃除", "适合大型组织"],
           "price": 189,
           "estimatedHoursSaved": 250,
           "itemsAbleToCreate": 500,
@@ -242,10 +228,7 @@
         },
         {
           "tier": "企业",
-          "description": [
-            "定制剃除额度",
-            "适合定制解决方案"
-          ],
+          "description": ["定制剃除额度", "适合定制解决方案"],
           "price": 99999,
           "estimatedHoursSaved": 0,
           "itemsAbleToCreate": 0,

--- a/content/pages/YakShaver/zh/home.json
+++ b/content/pages/YakShaver/zh/home.json
@@ -69,7 +69,7 @@
           "textOnLeft": true
         },
         {
-          "AboveHeaderText": "{剃除}",
+          "AboveHeaderText": "{Shave}",
           "Header": "2 - YakShaver 接管",
           "Description": "YakShaver 观看您的视频，将您说的话转成文本，并理解发生了什么。\n",
           "media": "/Browser2.png",
@@ -144,7 +144,7 @@
         "description": "当 PBI 被创建、分配或需要跟进时，立即保持更新"
       },
       "counterBox1": {
-        "title": "剃除的 Yaks 数量",
+        "title": "Shave的 Yaks 数量",
         "counterMetric": "YakShaved"
       },
       "counterBox2": {
@@ -182,11 +182,11 @@
     },
     {
       "title": "简单透明的定价",
-      "desc": "共享剃除额度。一次付费，组织内任何人都可以报告问题。不按人头收费——尽情剃除！",
+      "desc": "共享 Shave 额度。一次付费，组织内任何人都可以报告问题。不按人头收费——尽情 Shave！",
       "tiers": [
         {
           "tier": "入门",
-          "description": ["每月 15 次剃除", "适合个人"],
+          "description": ["每月 15 次 Shave", "适合个人"],
           "price": 0,
           "estimatedHoursSaved": 7.5,
           "itemsAbleToCreate": 15,
@@ -200,7 +200,7 @@
         },
         {
           "tier": "团队",
-          "description": ["每月 100 次剃除", "适合成长中的团队"],
+          "description": ["每月 100 次 Shave", "适合成长中的团队"],
           "price": 39,
           "estimatedHoursSaved": 50,
           "itemsAbleToCreate": 100,
@@ -214,7 +214,7 @@
         },
         {
           "tier": "成长",
-          "description": ["每月 500 次剃除", "适合大型组织"],
+          "description": ["每月 500 次 Shave", "适合大型组织"],
           "price": 189,
           "estimatedHoursSaved": 250,
           "itemsAbleToCreate": 500,
@@ -228,7 +228,7 @@
         },
         {
           "tier": "企业",
-          "description": ["定制剃除额度", "适合定制解决方案"],
+          "description": ["定制 Shave 额度", "适合定制解决方案"],
           "price": 99999,
           "estimatedHoursSaved": 0,
           "itemsAbleToCreate": 0,

--- a/content/pages/YakShaver/zh/install.json
+++ b/content/pages/YakShaver/zh/install.json
@@ -1,0 +1,66 @@
+{
+  "seo": {
+    "title": "安装",
+    "description": "立即下载、安装并开始剃须。"
+  },
+  "title": "安装",
+  "pageBlocks": [
+    {
+      "title": "选择您的平台",
+      "cards": [
+        {
+          "title": "桌面应用",
+          "descriptionLhs": "✓ 免费\n\n✓ 连接您喜爱的 MCP\n\n✓ 自带 AI 提供商\n",
+          "descriptionRhs": "✓ 安全的令牌存储\n\n✓ 原生独立应用\n\n✓ 自定义提示词\n",
+          "colSpan": "2",
+          "buttons": [
+            {
+              "label": "下载 Windows 版",
+              "url": "https://github.com/SSWConsulting/SSW.YakShaver.Desktop/releases/latest/download/YakShaver-latest-Setup.exe",
+              "icon": "/svg/windows.svg",
+              "iconPosition": "left",
+              "variant": "solidRed",
+              "size": "medium",
+              "_template": "actions"
+            },
+            {
+              "label": "下载 Mac 版",
+              "url": "https://github.com/SSWConsulting/SSW.YakShaver.Desktop/releases/latest/download/YakShaver-latest-arm64.dmg",
+              "icon": "/YakShaver/Docs/apple.svg",
+              "iconPosition": "left",
+              "variant": "solidRed",
+              "size": "medium",
+              "_template": "actions"
+            }
+          ]
+        },
+        {
+          "title": "Teams 应用扩展",
+          "descriptionLhs": "✓ 免费\n\n✓ 剃 Teams 录制\n\n✓ 在会议中协作\n\n✓ 自动处理录制\n\n✓ 内置命令\n",
+          "descriptionRhs": "",
+          "colSpan": "1",
+          "buttons": [
+            {
+              "label": "安装到 Teams",
+              "url": "https://teams.microsoft.com/l/app/f47ac10b-58cc-4372-a567-0e02b2c3d479",
+              "icon": "/svg/Microsoft Office Teams 2018.svg",
+              "iconPosition": "left",
+              "variant": "outlinedWhite",
+              "size": "medium",
+              "_template": "actions"
+            }
+          ]
+        }
+      ],
+      "_template": "downloadCards"
+    },
+    {
+      "altText": "制作完美的 PBI | YakShaver",
+      "title": "想了解更多？观看此视频！",
+      "externalVideoLink": "https://www.youtube.com/embed/CBes1SEvV54?si=Y5_GrdtZpjZfu8qN",
+      "thumbnail": "https://img.youtube.com/vi/CBes1SEvV54/maxresdefault.jpg",
+      "figureCaption": "视频：使用 YakShaver 制作完美的 PBI（6 分钟）",
+      "_template": "videoDisplay"
+    }
+  ]
+}

--- a/content/pages/YakShaver/zh/install.json
+++ b/content/pages/YakShaver/zh/install.json
@@ -36,7 +36,7 @@
         },
         {
           "title": "Teams 应用扩展",
-          "descriptionLhs": "✓ 免费\n\n✓ 剃 Teams 录制\n\n✓ 在会议中协作\n\n✓ 自动处理录制\n\n✓ 内置命令\n",
+          "descriptionLhs": "✓ 免费\n\n✓ Teams 录制\n\n✓ 在会议中协作\n\n✓ 自动处理录制\n\n✓ 内置命令\n",
           "descriptionRhs": "",
           "colSpan": "1",
           "buttons": [

--- a/content/pages/YakShaver/zh/mcp.json
+++ b/content/pages/YakShaver/zh/mcp.json
@@ -1,7 +1,7 @@
 {
   "seo": {
     "title": "试用 YakShaver MCP 测试版！",
-    "description": "试用 YakShaver MCP 测试版！下载、安装，今天就开始剃除牦牛毛。"
+    "description": "试用 YakShaver MCP 测试版！下载、安装，今天就开始 Shave。"
   },
   "title": "试用 YakShaver MCP 测试版！",
   "pageBlocks": [
@@ -27,8 +27,8 @@
           }
         },
         {
-          "title": "3. 剃除",
-          "description": "安装完成后，您就可以开始剃除牦牛毛了！有关详细说明，请观看下面的视频。\n",
+          "title": "3. Shave",
+          "description": "安装完成后，您就可以开始 Shave 了！有关详细说明，请观看下面的视频。\n",
           "image": {
             "imgSrc": "https://img.youtube.com/vi/CBes1SEvV54/maxresdefault.jpg",
             "imgLink": "https://www.youtube.com/embed/CBes1SEvV54?si=Y5_GrdtZpjZfu8qN",


### PR DESCRIPTION
- Remove `force-static` from [product]/[filename] route so getLocale() reads the x-language header at request time (force-static froze locale to build-time "en", causing /zh/pricing etc. to render English).
- Add content/pages/YakShaver/zh/install.json (Chinese install page; previously fell back to English due to missing file).
- Align zh navigation bar structure with the English version (add Install item, openInNewTab flags, CONTACT US + Portal buttons) keeping Chinese labels.
- Include pre-existing zh/home.json content tweaks.
- Fix the wording issue, see https://github.com/SSWConsulting/SSW.YakShaver/issues/3735