### PR TITLE
Fix black blog OG images in production: bundle public assets into the route

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,6 +5,16 @@ const nextConfig = {
   images: {
     domains: ["assets.tina.io", "img.youtube.com"],
   },
+  // The blog opengraph-image route reads banners/author photos from public/ via
+  // fs at runtime; dynamic paths aren't statically traced, so without this the
+  // files are missing from the serverless bundle and the image renders black
+  outputFileTracingIncludes: {
+    "/**/opengraph-image": [
+      "./public/*/Blogs/**/*",
+      "./public/*/Devs/**/*",
+      "./public/default-images/**/*",
+    ],
+  },
   async redirects() {
     return [
       {


### PR DESCRIPTION
## Summary

Follow-up to #773. After deploying, per-blog OG images rendered as a black 1200×630 rectangle in production while the global OG image worked.

**Root cause**: the `opengraph-image.tsx` route reads banner and author images from `public/` with `fs.readFile` using runtime-built paths. Next.js only bundles files it can statically trace into a serverless function, and dynamic `fs` paths aren't traceable — so in production the `public/` files were missing from the function bundle. Every `loadPublicImage` call returned `null` (by design, it swallows read errors for the fallback chain), and the route rendered just the bare `#161616` background: a black image. Locally it worked because dev serves straight from the project directory.

**Fix**: `outputFileTracingIncludes` in `next.config.mjs` forces the three needed folders into the route's bundle:

- `public/*/Blogs/**` (banners, ~4MB)
- `public/*/Devs/**` (author photos, ~0.5MB)
- `public/default-images/**` (fallback card, ~2MB)

Scoped to `/**/opengraph-image` routes only — `public/` in total is 147MB, so bundling all of it was not an option.

## Test plan

- [x] Dev route still serves the composited image (dev is unaffected by tracing)
- [ ] After deploy: `https://yakshaver.ai/blog/yakshaver-anywhere/opengraph-image` shows the banner + author composite instead of black

Note: this can't be fully verified locally — `tinacms build` requires the TinaCloud token that only CI has, and file tracing only happens during `next build`. The deploy preview is the real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)