### PR TITLE
Add anchor links to documentation headings (#589)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,9 @@
 {
-  "extends": ["next/core-web-vitals", "next/typescript"],
+  "root": true,
+  "extends": [
+    "next/core-web-vitals",
+    "next/typescript"
+  ],
   "rules": {
     "@typescript-eslint/no-explicit-any": "off"
   }

--- a/__tests__/LinkableHeading.test.tsx
+++ b/__tests__/LinkableHeading.test.tsx
@@ -6,12 +6,28 @@ import "@testing-library/jest-dom";
 import LinkableHeading from "../components/shared/LinkableHeading";
 
 describe("LinkableHeading", () => {
-  it("renders an h2 by default with slug id and self-link", () => {
+  it("renders an h2 by default with slug id and a sibling self-link", () => {
     render(<LinkableHeading>Getting Started</LinkableHeading>);
     const heading = screen.getByRole("heading", { level: 2 });
     expect(heading).toHaveAttribute("id", "getting-started");
-    const link = screen.getByRole("link", { name: "Getting Started" });
+    expect(heading).toHaveTextContent("Getting Started");
+    const link = screen.getByRole("link", { name: "Link to this section" });
     expect(link).toHaveAttribute("href", "#getting-started");
+    // the heading text is NOT inside the anchor
+    expect(link).not.toHaveTextContent("Getting Started");
+  });
+
+  it("keeps a content link and the self-link as siblings, never nested", () => {
+    render(
+      <LinkableHeading>
+        See the <a href="https://example.com/docs">docs</a>
+      </LinkableHeading>,
+    );
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(2);
+    // neither anchor contains the other
+    expect(links[0].contains(links[1])).toBe(false);
+    expect(links[1].contains(links[0])).toBe(false);
   });
 
   it("renders the requested tag", () => {

--- a/__tests__/LinkableHeading.test.tsx
+++ b/__tests__/LinkableHeading.test.tsx
@@ -64,6 +64,18 @@ describe("LinkableHeading", () => {
     expect(heading).toHaveAttribute("data-tina-field", "pricing.title");
   });
 
+  it("keeps the computed slug id even if a caller passes id", () => {
+    render(
+      <LinkableHeading as="h2" id="caller-supplied">
+        Getting Started
+      </LinkableHeading>,
+    );
+    expect(screen.getByRole("heading", { level: 2 })).toHaveAttribute(
+      "id",
+      "getting-started",
+    );
+  });
+
   it("renders a plain heading when no slug can be made", () => {
     render(<LinkableHeading as="h2">{"!!!"}</LinkableHeading>);
     const heading = screen.getByRole("heading", { level: 2 });

--- a/__tests__/LinkableHeading.test.tsx
+++ b/__tests__/LinkableHeading.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import LinkableHeading from "../components/shared/LinkableHeading";
+
+describe("LinkableHeading", () => {
+  it("renders an h2 by default with slug id and self-link", () => {
+    render(<LinkableHeading>Getting Started</LinkableHeading>);
+    const heading = screen.getByRole("heading", { level: 2 });
+    expect(heading).toHaveAttribute("id", "getting-started");
+    const link = screen.getByRole("link", { name: "Getting Started" });
+    expect(link).toHaveAttribute("href", "#getting-started");
+  });
+
+  it("renders the requested tag", () => {
+    render(<LinkableHeading as="h3">Deep Dive</LinkableHeading>);
+    expect(screen.getByRole("heading", { level: 3 })).toHaveAttribute(
+      "id",
+      "deep-dive",
+    );
+  });
+
+  it("prefers the anchor prop over children text", () => {
+    render(
+      <LinkableHeading anchor="Simple, {transparent} pricing">
+        <span>styled title</span>
+      </LinkableHeading>,
+    );
+    expect(screen.getByRole("heading", { level: 2 })).toHaveAttribute(
+      "id",
+      "simple-transparent-pricing",
+    );
+  });
+
+  it("preserves className and passes through extra props", () => {
+    render(
+      <LinkableHeading className="text-4xl" data-tina-field="pricing.title">
+        Plans
+      </LinkableHeading>,
+    );
+    const heading = screen.getByRole("heading", { level: 2 });
+    expect(heading).toHaveClass("text-4xl");
+    expect(heading).toHaveClass("scroll-mt-28");
+    expect(heading).toHaveAttribute("data-tina-field", "pricing.title");
+  });
+
+  it("renders a plain heading when no slug can be made", () => {
+    render(<LinkableHeading>{"!!!"}</LinkableHeading>);
+    const heading = screen.getByRole("heading", { level: 2 });
+    expect(heading).not.toHaveAttribute("id");
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/LinkableHeading.test.tsx
+++ b/__tests__/LinkableHeading.test.tsx
@@ -6,26 +6,24 @@ import "@testing-library/jest-dom";
 import LinkableHeading from "../components/shared/LinkableHeading";
 
 describe("LinkableHeading", () => {
-  it("renders an h2 by default with slug id and a sibling self-link", () => {
-    render(<LinkableHeading>Getting Started</LinkableHeading>);
+  it("renders the heading with a slug id and a sibling self-link", () => {
+    render(<LinkableHeading as="h2">Getting Started</LinkableHeading>);
     const heading = screen.getByRole("heading", { level: 2 });
     expect(heading).toHaveAttribute("id", "getting-started");
     expect(heading).toHaveTextContent("Getting Started");
     const link = screen.getByRole("link", { name: "Link to this section" });
     expect(link).toHaveAttribute("href", "#getting-started");
-    // the heading text is NOT inside the anchor
     expect(link).not.toHaveTextContent("Getting Started");
   });
 
   it("keeps a content link and the self-link as siblings, never nested", () => {
     render(
-      <LinkableHeading>
+      <LinkableHeading as="h2">
         See the <a href="https://example.com/docs">docs</a>
       </LinkableHeading>,
     );
     const links = screen.getAllByRole("link");
     expect(links).toHaveLength(2);
-    // neither anchor contains the other
     expect(links[0].contains(links[1])).toBe(false);
     expect(links[1].contains(links[0])).toBe(false);
   });
@@ -40,7 +38,7 @@ describe("LinkableHeading", () => {
 
   it("prefers the anchor prop over children text", () => {
     render(
-      <LinkableHeading anchor="Simple, {transparent} pricing">
+      <LinkableHeading as="h2" anchor="Simple, {transparent} pricing">
         <span>styled title</span>
       </LinkableHeading>,
     );
@@ -52,7 +50,11 @@ describe("LinkableHeading", () => {
 
   it("preserves className and passes through extra props", () => {
     render(
-      <LinkableHeading className="text-4xl" data-tina-field="pricing.title">
+      <LinkableHeading
+        as="h2"
+        className="text-4xl"
+        data-tina-field="pricing.title"
+      >
         Plans
       </LinkableHeading>,
     );
@@ -63,7 +65,7 @@ describe("LinkableHeading", () => {
   });
 
   it("renders a plain heading when no slug can be made", () => {
-    render(<LinkableHeading>{"!!!"}</LinkableHeading>);
+    render(<LinkableHeading as="h2">{"!!!"}</LinkableHeading>);
     const heading = screen.getByRole("heading", { level: 2 });
     expect(heading).not.toHaveAttribute("id");
     expect(screen.queryByRole("link")).not.toBeInTheDocument();

--- a/__tests__/anchorSlug.test.ts
+++ b/__tests__/anchorSlug.test.ts
@@ -1,0 +1,53 @@
+import { extractText, slugifyHeading } from "../utils/anchorSlug";
+import { createElement } from "react";
+
+describe("slugifyHeading", () => {
+  it("lowercases and dashes words", () => {
+    expect(slugifyHeading("Getting Started")).toBe("getting-started");
+  });
+
+  it("strips punctuation", () => {
+    expect(slugifyHeading("What's New, Today?")).toBe("whats-new-today");
+  });
+
+  it("strips curly brace formatter markers", () => {
+    expect(slugifyHeading("Simple, {transparent} pricing")).toBe(
+      "simple-transparent-pricing",
+    );
+  });
+
+  it("keeps unicode letters", () => {
+    expect(slugifyHeading("视频教程")).toBe("视频教程");
+  });
+
+  it("collapses whitespace and trims dashes", () => {
+    expect(slugifyHeading("  Multi   Space -- Here ")).toBe("multi-space-here");
+  });
+
+  it("returns empty string when nothing sluggable remains", () => {
+    expect(slugifyHeading("!!! ???")).toBe("");
+  });
+});
+
+describe("extractText", () => {
+  it("returns strings and numbers as-is", () => {
+    expect(extractText("Hello")).toBe("Hello");
+    expect(extractText(42)).toBe("42");
+  });
+
+  it("flattens arrays and nested elements", () => {
+    const node = createElement(
+      "span",
+      null,
+      "Hello ",
+      createElement("strong", null, "World"),
+    );
+    expect(extractText([node, "!"])).toBe("Hello World!");
+  });
+
+  it("ignores null, undefined and booleans", () => {
+    expect(extractText(null)).toBe("");
+    expect(extractText(undefined)).toBe("");
+    expect(extractText(true)).toBe("");
+  });
+});

--- a/__tests__/anchorSlug.test.ts
+++ b/__tests__/anchorSlug.test.ts
@@ -24,6 +24,10 @@ describe("slugifyHeading", () => {
     expect(slugifyHeading("  Multi   Space -- Here ")).toBe("multi-space-here");
   });
 
+  it("converts underscores to dashes", () => {
+    expect(slugifyHeading("hello_world")).toBe("hello-world");
+  });
+
   it("returns empty string when nothing sluggable remains", () => {
     expect(slugifyHeading("!!! ???")).toBe("");
   });

--- a/__tests__/anchorSlug.test.ts
+++ b/__tests__/anchorSlug.test.ts
@@ -50,4 +50,23 @@ describe("extractText", () => {
     expect(extractText(undefined)).toBe("");
     expect(extractText(true)).toBe("");
   });
+
+  it("reads tina rich-text AST via a content prop", () => {
+    const nested = createElement("div", {
+      content: [
+        { type: "text", text: "Connect " },
+        { type: "text", text: "GitHub", bold: true },
+      ],
+    } as Record<string, unknown>);
+    expect(extractText(nested)).toBe("Connect GitHub");
+  });
+
+  it("reads plain AST nodes with children", () => {
+    expect(
+      extractText({
+        type: "h2",
+        children: [{ type: "text", text: "Install" }],
+      }),
+    ).toBe("Install");
+  });
 });

--- a/__tests__/docAndBlogMarkdownStyle.test.tsx
+++ b/__tests__/docAndBlogMarkdownStyle.test.tsx
@@ -11,6 +11,32 @@ jest.mock("../components/shared/code-block/code-block", () => ({
 }));
 
 describe("DocAndBlogMarkdownStyle headings", () => {
+  it("anchors headings receiving tina's nested rich-text children", () => {
+    // Regression: TinaMarkdown passes a heading's text as a nested
+    // <TinaMarkdown content={ast}> element (text under props.content), not as
+    // plain string children. tinacms itself is ESM-only so we replicate that
+    // exact children shape instead of importing the real renderer.
+    const NestedMarkdown = () => null;
+    const Heading = DocAndBlogMarkdownStyle.h2!;
+    render(
+      <Heading>
+        {
+          <NestedMarkdown
+            {...({
+              content: [{ type: "text", text: "Connect Your GitHub Account" }],
+            } as Record<string, unknown>)}
+          />
+        }
+      </Heading>,
+    );
+    const heading = screen.getByRole("heading", { level: 2 });
+    expect(heading).toHaveAttribute("id", "connect-your-github-account");
+    expect(screen.getByRole("link")).toHaveAttribute(
+      "href",
+      "#connect-your-github-account",
+    );
+  });
+
   it.each([
     ["h1", 1],
     ["h2", 2],

--- a/__tests__/docAndBlogMarkdownStyle.test.tsx
+++ b/__tests__/docAndBlogMarkdownStyle.test.tsx
@@ -12,10 +12,8 @@ jest.mock("../components/shared/code-block/code-block", () => ({
 
 describe("DocAndBlogMarkdownStyle headings", () => {
   it("anchors headings receiving tina's nested rich-text children", () => {
-    // Regression: TinaMarkdown passes a heading's text as a nested
-    // <TinaMarkdown content={ast}> element (text under props.content), not as
-    // plain string children. tinacms itself is ESM-only so we replicate that
-    // exact children shape instead of importing the real renderer.
+    // Regression: tina passes heading text as a nested element (props.content),
+    // not a string. tinacms is ESM-only so we replicate that child shape here.
     const NestedMarkdown = () => null;
     const Heading = DocAndBlogMarkdownStyle.h2!;
     render(
@@ -42,12 +40,13 @@ describe("DocAndBlogMarkdownStyle headings", () => {
     ["h2", 2],
     ["h3", 3],
     ["h4", 4],
+    ["h5", 5],
+    ["h6", 6],
   ] as const)("%s renders an anchor-linked heading", (key, level) => {
     const Heading = DocAndBlogMarkdownStyle[key]!;
-    // tina types heading children as JSX.Element, so wrap the string in a
-    // fragment; extractText still reads it through props.children.
     render(
       <Heading>
+        {/* fragment satisfies tina's JSX.Element child typing */}
         <>{`Install Guide ${key}`}</>
       </Heading>,
     );

--- a/__tests__/docAndBlogMarkdownStyle.test.tsx
+++ b/__tests__/docAndBlogMarkdownStyle.test.tsx
@@ -1,0 +1,28 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { DocAndBlogMarkdownStyle } from "../tina/tinamarkdownStyles/DocAndBlogMarkdownStyle";
+
+// CodeBlock drags in shiki (ESM-only, jest can't parse it) and is irrelevant here
+jest.mock("../components/shared/code-block/code-block", () => ({
+  CodeBlock: () => null,
+}));
+
+describe("DocAndBlogMarkdownStyle headings", () => {
+  it.each([
+    ["h1", 1],
+    ["h2", 2],
+    ["h3", 3],
+    ["h4", 4],
+  ] as const)("%s renders an anchor-linked heading", (key, level) => {
+    const Heading = DocAndBlogMarkdownStyle[key]!;
+    render(<Heading>{`Install Guide ${key}`}</Heading>);
+    const heading = screen.getByRole("heading", { level });
+    expect(heading).toHaveAttribute("id", `install-guide-${key}`);
+    expect(
+      screen.getByRole("link", { name: `Install Guide ${key}` }),
+    ).toHaveAttribute("href", `#install-guide-${key}`);
+  });
+});

--- a/__tests__/docAndBlogMarkdownStyle.test.tsx
+++ b/__tests__/docAndBlogMarkdownStyle.test.tsx
@@ -53,8 +53,9 @@ describe("DocAndBlogMarkdownStyle headings", () => {
     );
     const heading = screen.getByRole("heading", { level });
     expect(heading).toHaveAttribute("id", `install-guide-${key}`);
+    expect(heading).toHaveTextContent(`Install Guide ${key}`);
     expect(
-      screen.getByRole("link", { name: `Install Guide ${key}` }),
+      screen.getByRole("link", { name: "Link to this section" }),
     ).toHaveAttribute("href", `#install-guide-${key}`);
   });
 });

--- a/__tests__/docAndBlogMarkdownStyle.test.tsx
+++ b/__tests__/docAndBlogMarkdownStyle.test.tsx
@@ -44,7 +44,13 @@ describe("DocAndBlogMarkdownStyle headings", () => {
     ["h4", 4],
   ] as const)("%s renders an anchor-linked heading", (key, level) => {
     const Heading = DocAndBlogMarkdownStyle[key]!;
-    render(<Heading>{`Install Guide ${key}`}</Heading>);
+    // tina types heading children as JSX.Element, so wrap the string in a
+    // fragment; extractText still reads it through props.children.
+    render(
+      <Heading>
+        <>{`Install Guide ${key}`}</>
+      </Heading>,
+    );
     const heading = screen.getByRole("heading", { level });
     expect(heading).toHaveAttribute("id", `install-guide-${key}`);
     expect(

--- a/app/[product]/[filename]/page.tsx
+++ b/app/[product]/[filename]/page.tsx
@@ -1,7 +1,7 @@
 import HomePageClient from "../../../components/shared/HomePageClient";
 import client from "../../../tina/__generated__/client";
 import { setPageMetadata } from "../../../utils/setPageMetaData";
-import { getLocale, getPageWithFallback, getRelativePath } from "../../../utils/i18n";
+import { getLocale, getPageWithFallback } from "../../../utils/i18n";
 import getPageData from "@utils/pages/getPageData";
 import NotFoundError from "@/errors/not-found";
 import ClientFallbackPage from "../../client-fallback-page";

--- a/app/[product]/docs/page.tsx
+++ b/app/[product]/docs/page.tsx
@@ -1,6 +1,5 @@
 import { notFound } from "next/navigation";
 import client from "../../../tina/__generated__/client";
-import { getLocale } from "../../../utils/i18n";
 import DocPost from "./[slug]/page";
 interface DocsIndex {
   params: Promise<{ product: string }>;

--- a/app/tina-api.client.ts
+++ b/app/tina-api.client.ts
@@ -1,5 +1,5 @@
 import getBlogPageData from "@utils/pages/getBlogPageData";
-import axios, { AxiosError, AxiosResponse } from "axios";
+import axios, { AxiosError } from "axios";
 import NotFoundError from "../src/errors/not-found";
 import getDocPageData from "@utils/pages/getDocPageData";
 import getPageData from "@utils/pages/getPageData";
@@ -7,8 +7,6 @@ import getPageData from "@utils/pages/getPageData";
 type QueryFunction = (product: string, relativePath: string) => Promise<unknown>;
 
 class ApiClient {
-  private static handle(response: AxiosResponse) {
-  }
   static queries: Record<string, QueryFunction> = {
       getBlogPageData: async (product: string, relativePath: string)=> {
       try{

--- a/components/search/SearchResults.tsx
+++ b/components/search/SearchResults.tsx
@@ -1,4 +1,3 @@
-import { PackageOpen } from "lucide-react";
 import { Hits, useInstantSearch } from "react-instantsearch";
 import SearchHighlight from "./SearchHighlight";
 

--- a/components/shared/LinkableHeading.tsx
+++ b/components/shared/LinkableHeading.tsx
@@ -9,8 +9,8 @@ type LinkableHeadingProps = {
   children?: ReactNode;
 } & HTMLAttributes<HTMLHeadingElement>;
 
-// ponytail: no dedup for repeated headings on a page; the second wins a
-// duplicate id. Add a per-page counter if authors need both to anchor.
+// Repeated headings on one page produce duplicate ids, so the anchor resolves
+// to the first occurrence. A per-page counter would be needed to disambiguate.
 export default function LinkableHeading({
   as: Tag,
   anchor,
@@ -22,17 +22,19 @@ export default function LinkableHeading({
 
   if (!slug) {
     return (
-      <Tag className={className} {...rest}>
+      <Tag {...rest} className={className}>
         {children}
       </Tag>
     );
   }
 
+  // Spread rest first so the component always owns id and className: a
+  // caller-supplied id must not override the computed anchor slug.
   return (
     <Tag
+      {...rest}
       id={slug}
       className={`group scroll-mt-28 ${className ?? ""}`}
-      {...rest}
     >
       {children}
       {/* sibling anchor, never wrapping children: heading text may contain its

--- a/components/shared/LinkableHeading.tsx
+++ b/components/shared/LinkableHeading.tsx
@@ -10,8 +10,13 @@ type LinkableHeadingProps = {
 } & HTMLAttributes<HTMLHeadingElement>;
 
 // Heading with its own anchor target per
-// https://www.ssw.com.au/rules/heading-to-anchor-targets - the heading links to
-// #slug and a link icon fades in on hover/focus.
+// https://www.ssw.com.au/rules/heading-to-anchor-targets - a link icon that
+// fades in on hover/focus links to #slug.
+// The icon is a SIBLING anchor, not a wrapper around the heading text: heading
+// content routinely contains its own markdown links, and wrapping it would nest
+// <a> inside <a> (invalid HTML -> the browser unnests it -> React hydration
+// mismatch). Keeping children as direct descendants also preserves any flex
+// layout the consumer put on the heading (e.g. the h4's inline-icon spacing).
 // ponytail: no dedup for duplicate headings on one page; add a per-page
 // counter context if authors ever repeat a heading and need both anchors.
 export default function LinkableHeading({
@@ -37,12 +42,13 @@ export default function LinkableHeading({
       className={`group scroll-mt-28 ${className ?? ""}`}
       {...rest}
     >
-      <a href={`#${slug}`} className="text-inherit no-underline">
-        {children}
-        <FaLink
-          aria-hidden="true"
-          className="ml-2 inline-block align-baseline text-[0.55em] text-ssw-red opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100"
-        />
+      {children}
+      <a
+        href={`#${slug}`}
+        aria-label="Link to this section"
+        className="ml-2 inline-flex items-center align-middle text-[0.6em] text-ssw-red opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100 focus:opacity-100"
+      >
+        <FaLink aria-hidden="true" />
       </a>
     </Tag>
   );

--- a/components/shared/LinkableHeading.tsx
+++ b/components/shared/LinkableHeading.tsx
@@ -9,8 +9,9 @@ type LinkableHeadingProps = {
   children?: ReactNode;
 } & HTMLAttributes<HTMLHeadingElement>;
 
-// Repeated headings on one page produce duplicate ids, so the anchor resolves
-// to the first occurrence. A per-page counter would be needed to disambiguate.
+// NOTE: no dedup for repeated headings on a page; duplicates share an id, and
+// links resolve to the first in document order. Add a per-page counter if
+// authors need both to anchor.
 export default function LinkableHeading({
   as: Tag,
   anchor,

--- a/components/shared/LinkableHeading.tsx
+++ b/components/shared/LinkableHeading.tsx
@@ -1,0 +1,49 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import { FaLink } from "react-icons/fa";
+import { extractText, slugifyHeading } from "@utils/anchorSlug";
+
+type LinkableHeadingProps = {
+  as?: "h1" | "h2" | "h3" | "h4";
+  /** Raw title to slugify; falls back to the text content of children. */
+  anchor?: string;
+  children?: ReactNode;
+} & HTMLAttributes<HTMLHeadingElement>;
+
+// Heading with its own anchor target per
+// https://www.ssw.com.au/rules/heading-to-anchor-targets - the heading links to
+// #slug and a link icon fades in on hover/focus.
+// ponytail: no dedup for duplicate headings on one page; add a per-page
+// counter context if authors ever repeat a heading and need both anchors.
+export default function LinkableHeading({
+  as: Tag = "h2",
+  anchor,
+  children,
+  className,
+  ...rest
+}: LinkableHeadingProps) {
+  const slug = slugifyHeading(anchor ?? extractText(children));
+
+  if (!slug) {
+    return (
+      <Tag className={className} {...rest}>
+        {children}
+      </Tag>
+    );
+  }
+
+  return (
+    <Tag
+      id={slug}
+      className={`group scroll-mt-28 ${className ?? ""}`}
+      {...rest}
+    >
+      <a href={`#${slug}`} className="text-inherit no-underline">
+        {children}
+        <FaLink
+          aria-hidden="true"
+          className="ml-2 inline-block align-baseline text-[0.55em] text-ssw-red opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100"
+        />
+      </a>
+    </Tag>
+  );
+}

--- a/components/shared/LinkableHeading.tsx
+++ b/components/shared/LinkableHeading.tsx
@@ -3,24 +3,16 @@ import { FaLink } from "react-icons/fa";
 import { extractText, slugifyHeading } from "@utils/anchorSlug";
 
 type LinkableHeadingProps = {
-  as?: "h1" | "h2" | "h3" | "h4";
+  as: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
   /** Raw title to slugify; falls back to the text content of children. */
   anchor?: string;
   children?: ReactNode;
 } & HTMLAttributes<HTMLHeadingElement>;
 
-// Heading with its own anchor target per
-// https://www.ssw.com.au/rules/heading-to-anchor-targets - a link icon that
-// fades in on hover/focus links to #slug.
-// The icon is a SIBLING anchor, not a wrapper around the heading text: heading
-// content routinely contains its own markdown links, and wrapping it would nest
-// <a> inside <a> (invalid HTML -> the browser unnests it -> React hydration
-// mismatch). Keeping children as direct descendants also preserves any flex
-// layout the consumer put on the heading (e.g. the h4's inline-icon spacing).
-// ponytail: no dedup for duplicate headings on one page; add a per-page
-// counter context if authors ever repeat a heading and need both anchors.
+// ponytail: no dedup for repeated headings on a page; the second wins a
+// duplicate id. Add a per-page counter if authors need both to anchor.
 export default function LinkableHeading({
-  as: Tag = "h2",
+  as: Tag,
   anchor,
   children,
   className,
@@ -43,6 +35,8 @@ export default function LinkableHeading({
       {...rest}
     >
       {children}
+      {/* sibling anchor, never wrapping children: heading text may contain its
+          own <a>, and nesting anchors is invalid HTML */}
       <a
         href={`#${slug}`}
         aria-label="Link to this section"

--- a/src/types/tina.ts
+++ b/src/types/tina.ts
@@ -1,4 +1,3 @@
-import type client from "@tina/__generated__/client";
 import { SystemInfo } from "@tina/__generated__/types";
 
 type RemoveTinaMetadata<T> = Omit<T, "__typename" | "_values" | "_sys"> & {

--- a/tina/tinamarkdownStyles/DocAndBlogMarkdownStyle.tsx
+++ b/tina/tinamarkdownStyles/DocAndBlogMarkdownStyle.tsx
@@ -64,6 +64,18 @@ export const DocAndBlogMarkdownStyle: Components<{
       {props?.children}
     </LinkableHeading>
   ),
+
+  h5: (props) => (
+    <LinkableHeading as="h5" className="text-base font-semibold mb-2 mt-6">
+      {props?.children}
+    </LinkableHeading>
+  ),
+
+  h6: (props) => (
+    <LinkableHeading as="h6" className="text-sm font-semibold mb-2 mt-6">
+      {props?.children}
+    </LinkableHeading>
+  ),
   // @ts-ignore - TODO: remove tsignore after typescript definitions for blockquotes are fixed
   // https://github.com/tinacms/tinacms/pull/6083
   blockquote: (props) => (

--- a/tina/tinamarkdownStyles/DocAndBlogMarkdownStyle.tsx
+++ b/tina/tinamarkdownStyles/DocAndBlogMarkdownStyle.tsx
@@ -5,6 +5,7 @@ import { Components } from "tinacms/dist/rich-text";
 import Link from "./Link";
 import { ImageEmbed } from "@comps/shared/Blocks/ImageEmbed";
 import { CodeBlock } from "@comps/shared/code-block/code-block";
+import LinkableHeading from "@comps/shared/LinkableHeading";
 
 export const DocAndBlogMarkdownStyle: Components<{
   Youtube: {
@@ -38,19 +39,30 @@ export const DocAndBlogMarkdownStyle: Components<{
   p: (props) => <p className="text-base font-light mb-4">{props?.children}</p>,
 
   h1: (props) => (
-    <h1 className="text-3xl font-bold mb-4 mt-4">{props?.children}</h1>
+    <LinkableHeading as="h1" className="text-3xl font-bold mb-4 mt-4">
+      {props?.children}
+    </LinkableHeading>
   ),
 
   h2: (props) => (
-    <h2 className="text-2xl font-semibold mb-4 mt-8">{props?.children}</h2>
+    <LinkableHeading as="h2" className="text-2xl font-semibold mb-4 mt-8">
+      {props?.children}
+    </LinkableHeading>
   ),
 
   h3: (props) => (
-    <h3 className="text-xl font-semibold mb-4 mt-8">{props?.children}</h3>
+    <LinkableHeading as="h3" className="text-xl font-semibold mb-4 mt-8">
+      {props?.children}
+    </LinkableHeading>
   ),
 
   h4: (props) => (
-    <h4 className="text-lg font-semibold mb-3 mt-6 flex items-center gap-2">{props?.children}</h4>
+    <LinkableHeading
+      as="h4"
+      className="text-lg font-semibold mb-3 mt-6 flex items-center gap-2"
+    >
+      {props?.children}
+    </LinkableHeading>
   ),
   // @ts-ignore - TODO: remove tsignore after typescript definitions for blockquotes are fixed
   // https://github.com/tinacms/tinacms/pull/6083

--- a/utils/anchorSlug.ts
+++ b/utils/anchorSlug.ts
@@ -15,12 +15,22 @@ export function slugifyHeading(text: string): string {
 }
 
 // Plain text of a rendered rich-text heading (bold/links/spans inside).
-export function extractText(node: ReactNode): string {
+// Handles both React children and Tina rich-text AST: TinaMarkdown renders a
+// heading's text as a nested <TinaMarkdown content={ast}> element, so the text
+// lives in props.content ({type, text, children} nodes), not props.children.
+export function extractText(node: unknown): string {
   if (node == null || typeof node === "boolean") return "";
   if (typeof node === "string" || typeof node === "number") return String(node);
   if (Array.isArray(node)) return node.map(extractText).join("");
-  if (typeof node === "object" && "props" in node) {
-    return extractText((node.props as { children?: ReactNode }).children);
+  if (typeof node === "object") {
+    if ("props" in node) {
+      const props = node.props as { children?: ReactNode; content?: unknown };
+      return extractText(props.children ?? props.content);
+    }
+    if ("text" in node) return String((node as { text: unknown }).text ?? "");
+    if ("children" in node) {
+      return extractText((node as { children: unknown }).children);
+    }
   }
   return "";
 }

--- a/utils/anchorSlug.ts
+++ b/utils/anchorSlug.ts
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react";
+
+// Anchor format per https://www.ssw.com.au/rules/heading-to-anchor-targets:
+// lowercase, dash-separated, punctuation stripped. Unicode letters are kept so
+// zh headings still get a usable anchor.
+export function slugifyHeading(text: string): string {
+  return text
+    .toLowerCase()
+    .normalize("NFKC")
+    .replace(/[^\p{L}\p{N}\s-]/gu, "")
+    .trim()
+    .replace(/[\s_]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+// Plain text of a rendered rich-text heading (bold/links/spans inside).
+export function extractText(node: ReactNode): string {
+  if (node == null || typeof node === "boolean") return "";
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(extractText).join("");
+  if (typeof node === "object" && "props" in node) {
+    return extractText((node.props as { children?: ReactNode }).children);
+  }
+  return "";
+}

--- a/utils/anchorSlug.ts
+++ b/utils/anchorSlug.ts
@@ -7,7 +7,7 @@ export function slugifyHeading(text: string): string {
   return text
     .toLowerCase()
     .normalize("NFKC")
-    .replace(/[^\p{L}\p{N}\s-]/gu, "")
+    .replace(/[^\p{L}\p{N}\s_-]/gu, "")
     .trim()
     .replace(/[\s_]+/g, "-")
     .replace(/-+/g, "-")

--- a/utils/anchorSlug.ts
+++ b/utils/anchorSlug.ts
@@ -1,36 +1,28 @@
-import type { ReactNode } from "react";
-
-// Anchor format per https://www.ssw.com.au/rules/heading-to-anchor-targets:
-// lowercase, dash-separated, punctuation stripped. Unicode letters are kept so
-// zh headings still get a usable anchor.
+// Slug for a heading anchor, per https://www.ssw.com.au/rules/heading-to-anchor-targets
 export function slugifyHeading(text: string): string {
   return text
     .toLowerCase()
-    .normalize("NFKC")
-    .replace(/[^\p{L}\p{N}\s_-]/gu, "")
+    .normalize("NFKC") // fold width/compatibility forms (e.g. full-width CJK)
+    .replace(/[^\p{L}\p{N}\s_-]/gu, "") // drop punctuation; keep letters/numbers of any script
     .trim()
-    .replace(/[\s_]+/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-|-$/g, "");
+    .replace(/[\s_]+/g, "-") // spaces and underscores become dashes
+    .replace(/-+/g, "-") // collapse repeated dashes
+    .replace(/^-|-$/g, ""); // trim leading/trailing dash
 }
 
-// Plain text of a rendered rich-text heading (bold/links/spans inside).
-// Handles both React children and Tina rich-text AST: TinaMarkdown renders a
-// heading's text as a nested <TinaMarkdown content={ast}> element, so the text
-// lives in props.content ({type, text, children} nodes), not props.children.
+// Plain text of a heading's children (string, React element, or Tina AST node).
 export function extractText(node: unknown): string {
-  if (node == null || typeof node === "boolean") return "";
   if (typeof node === "string" || typeof node === "number") return String(node);
   if (Array.isArray(node)) return node.map(extractText).join("");
-  if (typeof node === "object") {
-    if ("props" in node) {
-      const props = node.props as { children?: ReactNode; content?: unknown };
-      return extractText(props.children ?? props.content);
-    }
-    if ("text" in node) return String((node as { text: unknown }).text ?? "");
-    if ("children" in node) {
-      return extractText((node as { children: unknown }).children);
-    }
-  }
+  if (!node || typeof node !== "object") return "";
+
+  const n = node as {
+    props?: { children?: unknown; content?: unknown };
+    text?: unknown;
+    children?: unknown;
+  };
+  if (n.props) return extractText(n.props.children ?? n.props.content); // React element (Tina heading text lives in props.content)
+  if (n.text !== undefined) return extractText(n.text); // Tina AST leaf
+  if (n.children !== undefined) return extractText(n.children); // Tina AST branch
   return "";
 }


### PR DESCRIPTION
closes: #589 

## What

Documentation headings now carry anchor links, so readers can deep-link to a specific section per [SSW's heading-to-anchor rule](https://www.ssw.com.au/rules/heading-to-anchor-targets). Hovering a heading reveals a small link icon; clicking it puts a `#slug` on the URL, and loading a URL with that hash scrolls straight to the heading.

This covers every heading rendered from markdown: docs, blogs, the privacy page, and the rich-text blocks that share the same renderer. Because SSW.Products is one app serving all the product sites, this lands in a single shared place rather than per site.

## How it works

Two small pieces do the work, wired into the one markdown heading style map:

- `utils/anchorSlug.ts` turns heading text into a slug (`Getting Started` becomes `getting-started`). It keeps unicode letters so Chinese headings still get a usable anchor, and it walks the rich-text tree to read a heading's text whether TinaMarkdown hands it a plain string, a React element, or a nested AST node.
- `components/shared/LinkableHeading.tsx` renders the heading with `id={slug}` and a sibling link icon. The icon is a separate anchor placed after the heading content, never a wrapper around it, because heading text often contains its own markdown links and nesting `<a>` inside `<a>` is invalid HTML. `scroll-mt` keeps the anchored heading clear of the sticky navbar.

## Reviewed

This branch went through an independent multi-model review before opening. It caught and we fixed: a build-breaking test type (a bare string where TinaCMS types heading children as `JSX.Element`, which `tsc`/`next build` rejected while SWC-based jest hid it), the nested-anchor issue above, and a slug bug where underscores were stripped before they could become dashes. One limitation is documented in code: repeated headings on a page are not de-duplicated, so identical headings share an id.

## Testing

- `pnpm test` - 34 passing (slug rules incl. unicode and the tina AST shape; the component's id/self-link/sibling structure; a regression test proving a content link and the self-link never nest; the markdown map anchoring h1 through h6).
- `npx tsc --noEmit` - clean.
- Verified in the running app: hover icon, click-to-hash, hash-on-load scroll, and a heading with two inline content links renders with zero nested anchors and no hydration errors.

## Suggested review order

1. `utils/anchorSlug.ts` - the slug + text-extraction helpers everything builds on.
2. `components/shared/LinkableHeading.tsx` - the shared component; note the sibling-anchor structure and why.
3. `tina/tinamarkdownStyles/DocAndBlogMarkdownStyle.tsx` - where h1 through h6 are wired to the component (the one place that reaches all doc/blog/rich-text headings).
4. `__tests__/anchorSlug.test.ts`, `__tests__/LinkableHeading.test.tsx`, `__tests__/docAndBlogMarkdownStyle.test.tsx` - behaviour and the nested-anchor regression guard.
5. `.eslintrc.json` and the unused-import removals - housekeeping, skimmable.

