### PR TITLE
Add Events entry to Community menu (links to /conference)

### DIFF
--- a/content/navBars/YakShaver/YakShaver-NavigationBar.json
+++ b/content/navBars/YakShaver/YakShaver-NavigationBar.json
@@ -35,6 +35,10 @@
       "label": "COMMUNITY",
       "items": [
         {
+          "label": "EVENTS",
+          "href": "/conference"
+        },
+        {
           "label": "SUPPORT",
           "href": "/docs/support"
         },

--- a/content/navBars/YakShaver/zh/YakShaver-NavigationBar.json
+++ b/content/navBars/YakShaver/zh/YakShaver-NavigationBar.json
@@ -35,6 +35,10 @@
       "label": "社区",
       "items": [
         {
+          "label": "活动",
+          "href": "/conference"
+        },
+        {
           "label": "支持",
           "href": "/docs/support"
         },


### PR DESCRIPTION
## Summary
- Adds an "Events" entry (top of the list) to the Community dropdown menu on the YakShaver site, linking to the existing `/conference` page
- Updates both English and Chinese navigation JSON files

## Test plan
- [ ] Verify the Community dropdown shows "Events" as the first item on desktop
- [ ] Verify it also appears in the mobile menu
- [ ] Click through to confirm it navigates to /conference
- [ ] Check Chinese locale shows "活动" and links correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)